### PR TITLE
Feature/jkw push notifications

### DIFF
--- a/src/Components/About/About.js
+++ b/src/Components/About/About.js
@@ -7,7 +7,7 @@ const About = () => {
       <section>
         <h2 className={style.prompt}>About Som Timer</h2>
         <article className={style.appDescription}>
-          <p><span className={style.somTimer}>Som Timer</span> is a timer that cares. Inspired by the <a href="https://francescocirillo.com/pages/pomodoro-technique" target="_blank">Pomodoro Technique® `</a>, the practice of taking regular breaks at set intervals to fight cognitive boredom and burnout, increase productivity, and boost motivation, Som Timer takes the concept one step further. We at Som Timer believe that what you do on your breaks is just as important as the decision to take those breaks. </p>
+          <p><span className={style.somTimer}>Som Timer</span> is a timer that cares. Inspired by the <a href="https://francescocirillo.com/pages/pomodoro-technique" target="_blank">Pomodoro Technique®</a>, the practice of taking regular breaks at set intervals to fight cognitive boredom and burnout, increase productivity, and boost motivation, Som Timer takes the concept one step further. We at Som Timer believe that what you do on your breaks is just as important as the decision to take those breaks. </p>
           <p>Mindfulness meditation and other somatic exercises have been linked to enhanced productivity, boosted mental health, and stress reduction. To encourage this state of mind and take the guesswork out of your breaks, Som Timer provides mindfulness-related content for you during your break intervals, so you can get back to work feeling refreshed, calm, and ready to tackle the next task.</p>
           <p className={style.disclaimer}>This timer is not affiliated with, associated with, or endorsed by the Pomodoro Technique®<br/> or its creator, Francesco Cirillo. 
           </p>

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -11,6 +11,15 @@ import PageNotFound from '../PageNotFound/PageNotFound'
 import './App.scss'
 
 function App() {
+  if (!('Notification' in window)) {
+    console.log('This browser does not support notifications!')
+    return;
+  }
+
+  Notification.requestPermission(status => {
+    console.log('Notification permission status:', status)
+  })
+  
   return (
     <section className="App">
       <Header />

--- a/src/Components/CountdownTimer/CountdownTimer.js
+++ b/src/Components/CountdownTimer/CountdownTimer.js
@@ -21,6 +21,26 @@ const CountdownTimer = () => {
   //   circlePath.style.animation = `countDown ${settings.workInterval * 60} linear`
   // }
 
+  const displayNotification = () => {
+    if(Notification.permission == 'granted') {
+      navigator.serviceWorker.getRegistration().then(reg => {
+        const options = {
+          body: 'Return to Som Timer to choose your break content',
+          icon: '/favicon.ico',
+          vibrate: [100, 50, 100],
+          data: {
+            dateOfArrival: Date.now(),
+            primaryKey: 999
+          },
+          actions: [
+            {action: 'close', title: 'Close the notification', icon: ''}
+          ]
+        }
+        reg.showNotification('Focus Interval Complete', options)
+      })
+    }
+  }
+
   return (
     <div className={style.countdownTimer}>
       <h2 className={style.prompt}>Click ▶ to Begin Focusing</h2>
@@ -33,7 +53,10 @@ const CountdownTimer = () => {
         checkpoints={[
           {
             time: 0,
-            callback: () => timerDone(),
+            callback: () => {
+              displayNotification()
+              timerDone()
+            },
           },
         ]}
       >

--- a/src/sw-custom.js
+++ b/src/sw-custom.js
@@ -67,6 +67,24 @@ if ("function" === typeof importScripts) {
         ],
       })
     );
+
+    // Notification event listeners  
+    self.addEventListener('notificationclose', event => {
+      const notification = event.notification;
+      const primaryKey = notification.data.primaryKey;
+
+      console.log('Close notification: ' + primaryKey)
+    })
+
+    self.addEventListener('notificationclick', event => {
+      const notification = event.notification;
+      const action = event.action;
+
+      if (action === 'close') {
+        notification.close()
+      }
+    })
+
   } else {
     console.error("Workbox could not be loaded. No offline support");
   }


### PR DESCRIPTION
# Som Timer Pull Request Form
## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
- This PR adds notification functionality via the [Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API). Now, when the timer finishes counting down, users receive a notification encouraging them to visit our site again to choose their wellness content.
- Closes #62 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?
- [ ] No
- [x] Yes
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
- Ran `npm test` to confirm all passing tests
- To manually check this, I ran `npm run build` from the root directory of my app to create the latest build of this application. Then, I ran `serve -s build` in the terminal to open the app at `http://localhost:5000`. When the `CountdownTimer` hits zero, a notification is provided to the user (see gif below).
     - Note: read "message for reviewer" below for one potential hangup with this functionality...

# Message for reviewer:
- I'm not entirely sure that this functionality is fully operational! In order to test this functionality locally, I had to [temporarily disable](https://stackoverflow.com/questions/53011652/desktop-notification-not-appearing-in-chrome) the `Enable native notifications` section when I visit `chrome://flags` in the browser (see screenshot below). Based on some of the research I did, I'm hoping this issue will sort itself out when we visit this page with an `https` protocol and that this extra step is necessary only when running the site with `http`.
     - You can confirm that the notification is getting triggered in the dev tools, even without this workaround, by visiting the `Application` tab, then navigating to `Notifications` under `Background Services`. If you hit the record button, and then let the timer countdown, you'll see the notification event firing as expected (even though it doesn't show up on screen).
# Checklist:
- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
# Screenshots
![somTimer_notifications v1](https://user-images.githubusercontent.com/62263439/97791236-cab70080-1b95-11eb-86f0-601d17135f77.gif)
<img width="1433" alt="Screen Shot 2020-10-31 at 4 19 44 PM" src="https://user-images.githubusercontent.com/62263439/97791162-e5d54080-1b94-11eb-81cd-226aa1203404.png">