### PR TITLE
Feature/rw mood settings

### DIFF
--- a/src/Components/App/App.test.js
+++ b/src/Components/App/App.test.js
@@ -183,7 +183,7 @@ describe('App', () => {
     expect(contentSelectionHeading).toBeInTheDocument()
   })
 
-  it('should take you to a content selection screen after the first mood rating', async () => {
+  it('should take you to a content selection screen after the first mood rating when mood is enabled', async () => {
     getSettings.mockResolvedValueOnce({
       data: {
         id: 1,
@@ -224,7 +224,7 @@ describe('App', () => {
     expect(contentSelectionHeading).toBeInTheDocument()
   })
 
-  it('should allow a user to select somatic content when mood rating 1 is complete, and receive somatic content', async () => {
+  it('should allow a user to select the category of somatic content when mood rating 1 is complete, and then receive somatic content', async () => {
     getSettings.mockResolvedValueOnce({
       data: {
         id: 1,
@@ -277,14 +277,14 @@ describe('App', () => {
     expect(contentDeliveryHeading).toBeInTheDocument()
   })
 
-  it('should allow a user to select breathwork/meditation content when mood rating 1 is complete and receive meditation content', async () => {
+  it('should allow a user to select breathwork/meditation content and receive meditation content', async () => {
     getSettings.mockResolvedValueOnce({
       data: {
         id: 1,
         rest_interval: '5',
         work_interval: '30',
         sound: 'reverbSplash',
-        mood: true
+        mood: false
       }
     })
 
@@ -315,12 +315,6 @@ describe('App', () => {
     const skipIcon = await waitFor(() => getByRole('button', { name: /skip/i }))
 
     fireEvent.click(skipIcon)
-
-    const moodRating1 = getByRole('button', { name: /1 out of 5/ })
-    const submitButton = getByRole('button', { name: /submit/i })
-
-    fireEvent.click(moodRating1)
-    fireEvent.click(submitButton)
 
     const meditationBtn = getByRole('button', { name: /breathwork\/meditation/i })
 
@@ -385,7 +379,7 @@ describe('App', () => {
     expect(contentDeliveryHeading).toBeInTheDocument()
   })
 
-  it('should allow a user to select content when the timer runs down, mood rating 1 is complete, & then see the video, skip it, and be taken to mood rating 2', async () => {
+  it('if mood is enabled, should allow a user to select content when the timer runs down, mood rating 1 is complete, & then see the video, skip it, and be taken to mood rating 2', async () => {
     getSettings.mockResolvedValueOnce({
       data: {
         id: 1,
@@ -442,7 +436,58 @@ describe('App', () => {
     expect(moodHeading).toBeInTheDocument()
   })
 
-  it('should display the FocusModal text & make a post request with session data once the user has completed a full cycle', async () => {
+  it('if mood is disabled, should allow a user to select content when the timer runs down, then see the video, skip it, and see a transition modal', async () => {
+    getSettings.mockResolvedValueOnce({
+      data: {
+        id: 1,
+        rest_interval: '5',
+        work_interval: '30',
+        sound: 'reverbSplash',
+        mood: false
+      }
+    })
+
+    getRandomContent.mockResolvedValue({
+      data: {
+        category: "SomaticCategory.MOVEMENT",
+        duration: "5:00",
+        id: 1,
+        url: "https://www.youtube.com/watch?v=dsmfIAyiois"
+      }
+    })
+
+    const { getByRole } = render(
+      <MemoryRouter>
+        <SettingsProvider>
+          <ViewProvider>
+            <SessionProvider>
+              <VideoProvider>
+                <App />
+              </VideoProvider>
+            </SessionProvider>
+          </ViewProvider>
+        </SettingsProvider>
+      </MemoryRouter>
+    )
+
+    const skipIcon = await waitFor(() => getByRole('button', { name: /skip/i }))
+
+    fireEvent.click(skipIcon)
+
+    const yogaBtn = getByRole('button', { name: /yoga\/movement/i })
+
+    fireEvent.click(yogaBtn)
+
+    const skipVideoBtn = await waitFor(() => getByRole('button', { name: /skip break/i }))
+
+    fireEvent.click(skipVideoBtn)
+
+    const modalContent = getByRole('heading', { name: /you're doing great\. get ready to focus\./i })
+
+    expect(modalContent).toBeInTheDocument()
+  })
+
+  it('should display the FocusModal text & make a post request with session data once the user has completed a full cycle including mood ratings', async () => {
     getSettings.mockResolvedValueOnce({
       data: {
         id: 1,

--- a/src/Components/App/App.test.js
+++ b/src/Components/App/App.test.js
@@ -149,6 +149,40 @@ describe('App', () => {
     expect(moodRatingHeading).toBeInTheDocument()
   })
 
+  it('should take you to the content selection screen when the timer is skipped if mood is disabled', async () => {
+    getSettings.mockResolvedValueOnce({
+      data: {
+        id: 1,
+        rest_interval: '5',
+        work_interval: '30',
+        sound: 'reverbSplash',
+        mood: false
+      }
+    })
+
+    const { getByRole } = render(
+      <MemoryRouter>
+        <SettingsProvider>
+          <ViewProvider>
+            <SessionProvider>
+              <VideoProvider>
+                <App />
+              </VideoProvider>
+            </SessionProvider>
+          </ViewProvider>
+        </SettingsProvider>
+      </MemoryRouter>
+    )
+
+    const skipIcon = await waitFor(() => getByRole('button', { name: /skip/i }))
+
+    fireEvent.click(skipIcon)
+
+    const contentSelectionHeading = getByRole('heading', { name: /how would you like to spend your break\?/i })
+
+    expect(contentSelectionHeading).toBeInTheDocument()
+  })
+
   it('should take you to a content selection screen after the first mood rating', async () => {
     getSettings.mockResolvedValueOnce({
       data: {

--- a/src/Components/App/App.test.js
+++ b/src/Components/App/App.test.js
@@ -9,7 +9,6 @@ import { SessionProvider } from '../../Context/SessionContext'
 import { MemoryRouter } from 'react-router-dom'
 import { getSettings, updateSettings, getRandomContent, postSession } from '../../apiCalls'
 jest.mock('../../apiCalls.js')
-// jest.useFakeTimers()
 
 describe('App', () => {
   it('should bring users to the timer view on load and allow them to visit the Stats, About, and Settings pages', async () => {
@@ -116,13 +115,14 @@ describe('App', () => {
     expect(timerLength).toBeInTheDocument()
   })
 
-  it('should take you to a mood rating screen when the timer is skipped', async () => {
+  it('should take you to a mood rating screen when the timer is skipped if mood is enabled', async () => {
     getSettings.mockResolvedValueOnce({
       data: {
         id: 1,
         rest_interval: '5',
         work_interval: '30',
-        sound: 'chordCliff'
+        sound: 'reverbSplash',
+        mood: true
       }
     })
 
@@ -155,7 +155,8 @@ describe('App', () => {
         id: 1,
         rest_interval: '5',
         work_interval: '30',
-        sound: 'chordCliff'
+        sound: 'reverbSplash',
+        mood: true
       }
     })
 
@@ -195,7 +196,8 @@ describe('App', () => {
         id: 1,
         rest_interval: '5',
         work_interval: '30',
-        sound: 'chordCliff'
+        sound: 'reverbSplash',
+        mood: true
       }
     })
 
@@ -247,7 +249,8 @@ describe('App', () => {
         id: 1,
         rest_interval: '5',
         work_interval: '30',
-        sound: 'chordCliff'
+        sound: 'reverbSplash',
+        mood: true
       }
     })
 
@@ -300,7 +303,8 @@ describe('App', () => {
         id: 1,
         rest_interval: '5',
         work_interval: '30',
-        sound: 'chordCliff'
+        sound: 'reverbSplash',
+        mood: true
       }
     })
 
@@ -353,7 +357,8 @@ describe('App', () => {
         id: 1,
         rest_interval: '5',
         work_interval: '30',
-        sound: 'chordCliff'
+        sound: 'reverbSplash',
+        mood: true
       }
     })
 
@@ -409,7 +414,8 @@ describe('App', () => {
         id: 1,
         rest_interval: '5',
         work_interval: '30',
-        sound: 'chordCliff'
+        sound: 'reverbSplash',
+        mood: true
       }
     })
 

--- a/src/Components/ContentDelivery/ContentDelivery.js
+++ b/src/Components/ContentDelivery/ContentDelivery.js
@@ -23,7 +23,6 @@ const ContentDelivery = () => {
 
   const handleEnded = () => {
     recordBreakInterval()
-    // setView('mood-rating-2')
     settings.moodRating ? setView('mood-rating-2') : setSessionComplete(true)
   }
 

--- a/src/Components/ContentDelivery/ContentDelivery.js
+++ b/src/Components/ContentDelivery/ContentDelivery.js
@@ -1,5 +1,6 @@
-import React, { useContext } from 'react'
+import React, { useState, useContext } from 'react'
 import style from './ContentDelivery.module.scss'
+import FocusModal from '../FocusModal/FocusModal'
 import ReactPlayer from 'react-player'
 import { VideoContext } from '../../Context/VideoContext'
 import { ViewContext } from '../../Context/ViewContext'
@@ -7,6 +8,7 @@ import { SettingsContext } from '../../Context/SettingsContext'
 import { SessionContext } from '../../Context/SessionContext'
 
 const ContentDelivery = () => {
+  const [sessionComplete, setSessionComplete] = useState(false)
   const [ videoLink ] = useContext(VideoContext)
   const setView = useContext(ViewContext)[1]
   const [ settings ] = useContext(SettingsContext)
@@ -21,12 +23,13 @@ const ContentDelivery = () => {
 
   const handleEnded = () => {
     recordBreakInterval()
-    setView('mood-rating-2')
+    // setView('mood-rating-2')
+    settings.moodRating ? setView('mood-rating-2') : setSessionComplete(true)
   }
 
   return (
     <>
-      <section className={style.videoSection}>
+      <section className={!sessionComplete ? style.videoSection : style.endSessionModal}>
         <h2 className={style.prompt}>Enjoy Your Break!</h2>
         <div className={style.videoWrapper}>
           <ReactPlayer
@@ -41,14 +44,12 @@ const ContentDelivery = () => {
         </div>
         <button 
           className={style.skipBtn} 
-          onClick={() => {
-            setView('mood-rating-2')
-            recordBreakInterval()
-          }}
+          onClick={handleEnded}
         >
           Skip Break
         </button>
       </section>
+      {sessionComplete && <FocusModal />}
     </>       
   )
 }

--- a/src/Components/ContentDelivery/ContentDelivery.module.scss
+++ b/src/Components/ContentDelivery/ContentDelivery.module.scss
@@ -14,6 +14,11 @@
   margin: 1em 1em 0;
 }
 
+.endSessionModal {
+  @extend .videoSection;
+  -webkit-filter: blur(5px) grayscale(50%);
+}
+
 .videoWrapper {
   @include size(42em, 21.4em);
   display: flex;

--- a/src/Components/CountdownTimer/CountdownTimer.js
+++ b/src/Components/CountdownTimer/CountdownTimer.js
@@ -37,8 +37,12 @@ const CountdownTimer = () => {
     })
   }
 
+  const setNextView = () => {
+    settings.moodRating ? setView('mood-rating-1') : setView('content-selection')
+  }
+
   const timerDone = () => {
-    setView('mood-rating-1')
+    // settings.moodRating ? setView('mood-rating-1') : setView('content-selection')
     if (!('Notification' in window) || Notification.permission !== 'granted') {
       toastNotify()
     } else {
@@ -46,6 +50,7 @@ const CountdownTimer = () => {
     }
     playAlertSound(settings.sound)
     recordFocusInterval(settings.workInterval)
+    setNextView()
   }
 
   return (
@@ -166,7 +171,8 @@ const CountdownTimer = () => {
                 onClick={() => {
                   const timeElapsed = (((settings.workInterval * 60000) - getTime()) / 60000).toFixed(2)
                   recordFocusInterval(timeElapsed)
-                  setView('mood-rating-1')
+                  setNextView()
+                  // settings.moodRating ? setView('mood-rating-1') : setView('content-selection')
                 }}
               >
                 <img

--- a/src/Components/CountdownTimer/CountdownTimer.js
+++ b/src/Components/CountdownTimer/CountdownTimer.js
@@ -42,7 +42,6 @@ const CountdownTimer = () => {
   }
 
   const timerDone = () => {
-    // settings.moodRating ? setView('mood-rating-1') : setView('content-selection')
     if (!('Notification' in window) || Notification.permission !== 'granted') {
       toastNotify()
     } else {
@@ -172,7 +171,6 @@ const CountdownTimer = () => {
                   const timeElapsed = (((settings.workInterval * 60000) - getTime()) / 60000).toFixed(2)
                   recordFocusInterval(timeElapsed)
                   setNextView()
-                  // settings.moodRating ? setView('mood-rating-1') : setView('content-selection')
                 }}
               >
                 <img

--- a/src/Components/Settings/Settings.js
+++ b/src/Components/Settings/Settings.js
@@ -76,10 +76,11 @@ const Settings = () => {
           <option value={'random'}>Randomize My Sounds</option>
         </select>
       </div>
+      <div className={style.line}></div>
       <div className={style.intervalContainer}>
-        <p className={style.intervalLabel}>Toggle mood ratings</p>
+        <p className={style.intervalLabel}>{settings.moodRating ? 'Disable' : 'Enable'} mood ratings</p>
         <label class={style.switch}>
-          <input type="checkbox" className={style.inputToggle}/>
+          <input type="checkbox" className={style.inputToggle} checked={settings.moodRating}/>
           <span class={style.slider}></span>
         </label>
       </div>

--- a/src/Components/Settings/Settings.js
+++ b/src/Components/Settings/Settings.js
@@ -91,6 +91,7 @@ const Settings = () => {
             type="checkbox" 
             className={style.inputToggle} 
             checked={settings.moodRating}
+            data-testid="moodRating"
             onClick={toggleMood}
           />
           <span class={style.slider}></span>

--- a/src/Components/Settings/Settings.js
+++ b/src/Components/Settings/Settings.js
@@ -76,6 +76,13 @@ const Settings = () => {
           <option value={'random'}>Randomize My Sounds</option>
         </select>
       </div>
+      <div className={style.intervalContainer}>
+        <p className={style.intervalLabel}>Toggle mood ratings</p>
+        <label class={style.switch}>
+          <input type="checkbox" className={style.inputToggle}/>
+          <span class={style.slider}></span>
+        </label>
+      </div>
       <div className={style.line}></div>
       <p className={style.saveAutomatically}>
         <span role="img" alt="sparkle emoji" aria-label="sparkle emoji">

--- a/src/Components/Settings/Settings.js
+++ b/src/Components/Settings/Settings.js
@@ -21,6 +21,13 @@ const Settings = () => {
     })
   }
 
+  const toggleMood = () => {
+    setSettings({
+      ...settings,
+      moodRating: !settings.moodRating
+    })
+  }
+
   return (
     <div className={style.settingsContainer}>
       <h2 className={style.settingsHeader}>Settings</h2>
@@ -80,7 +87,12 @@ const Settings = () => {
       <div className={style.intervalContainer}>
         <p className={style.intervalLabel}>{settings.moodRating ? 'Disable' : 'Enable'} mood ratings</p>
         <label class={style.switch}>
-          <input type="checkbox" className={style.inputToggle} checked={settings.moodRating}/>
+          <input 
+            type="checkbox" 
+            className={style.inputToggle} 
+            checked={settings.moodRating}
+            onClick={toggleMood}
+          />
           <span class={style.slider}></span>
         </label>
       </div>

--- a/src/Components/Settings/Settings.module.scss
+++ b/src/Components/Settings/Settings.module.scss
@@ -66,6 +66,54 @@
   letter-spacing: 1px;
 }
 
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 56px;
+  height: 30px; 
+
+  input {
+    opacity: 0;
+    @include size(0, 0);
+  }
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+.inputToggle:checked + .slider {
+  background-color: $salmon; 
+} 
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: $lightBlueAccent;
+   -webkit-transition: .4s;
+  transition: .4s;
+  border-radius: 1em; 
+
+  &:before {
+    position: absolute; 
+    content: '';
+    @include size(22px, 22px);
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+    border-radius: 1em; 
+  }
+}
+
+
 @media screen and (max-width: 688px) {
   .settingsContainer {
     @include size(300px, 400px);

--- a/src/Components/Settings/Settings.test.js
+++ b/src/Components/Settings/Settings.test.js
@@ -17,14 +17,16 @@ describe('Settings', () => {
     const workIntervalInput = getByTestId('workInterval')
     const breakIntervalInput = getByTestId('breakInterval')
     const soundInput = getByTestId('sound')
+    const moodRatingInput = getByTestId('moodRating')
 
     expect(settingsHeader).toBeInTheDocument()
     expect(workIntervalInput).toBeInTheDocument()
     expect(breakIntervalInput).toBeInTheDocument()
     expect(soundInput).toBeInTheDocument()
+    expect(moodRatingInput).toBeInTheDocument()
   })
 
-  it('Should have default values for the breakInterval select', () => {
+  it('Should have default values for the breakInterval select and moodRating slider', () => {
 
     const { getByTestId } = render(
       <SettingsProvider>
@@ -33,8 +35,10 @@ describe('Settings', () => {
     )
 
     const breakIntervalInput = getByTestId('breakInterval')
+    const moodRatingInput = getByTestId('moodRating')
 
     expect(breakIntervalInput.value).toBe('5')
+    expect(moodRatingInput.checked).toBe(true)
   })
 
   it('Should update its values on change', () => {
@@ -48,13 +52,16 @@ describe('Settings', () => {
     const workIntervalInput = getByTestId('workInterval')
     const breakIntervalInput = getByTestId('breakInterval')
     const soundInput = getByTestId("sound");
+    const moodRatingInput = getByTestId('moodRating')
 
     fireEvent.blur(workIntervalInput, { target: { value: '45' } })
     fireEvent.blur(breakIntervalInput, { target: { value: '10' } })
     fireEvent.change(soundInput, { target: { value: 'balineseGong' } })
+    fireEvent.click(moodRatingInput);
 
     expect(workIntervalInput.value).toBe('45')
     expect(breakIntervalInput.value).toBe('10')
     expect(soundInput.value).toBe('balineseGong')
+    expect(moodRatingInput.checked).toBe(false)
   })
 })

--- a/src/Context/SettingsContext.js
+++ b/src/Context/SettingsContext.js
@@ -12,7 +12,7 @@ export const SettingsProvider = ({ children }) => {
         const workInterval = response.data.work_interval.split(':')[0]
         const breakInterval = response.data.rest_interval.split(':')[0]
         const sound = response.data.sound
-        // const moodRating = response.data.mood_rating
+        // const moodRating = response.data.mood
         //NOTE: delete line below
         const moodRating = true
         setSettings({ workInterval, breakInterval, sound, moodRating})

--- a/src/Context/SettingsContext.js
+++ b/src/Context/SettingsContext.js
@@ -12,9 +12,7 @@ export const SettingsProvider = ({ children }) => {
         const workInterval = response.data.work_interval.split(':')[0]
         const breakInterval = response.data.rest_interval.split(':')[0]
         const sound = response.data.sound
-        // const moodRating = response.data.mood
-        //NOTE: delete line below
-        const moodRating = true
+        const moodRating = response.data.mood
         setSettings({ workInterval, breakInterval, sound, moodRating})
       })
       .catch(err => {

--- a/src/Context/SettingsContext.js
+++ b/src/Context/SettingsContext.js
@@ -13,8 +13,9 @@ export const SettingsProvider = ({ children }) => {
         const breakInterval = response.data.rest_interval.split(':')[0]
         const sound = response.data.sound
         // const moodRating = response.data.mood_rating
-        //NOTE: add 'moodRating' to setSettings below
-        setSettings({ workInterval, breakInterval, sound})
+        //NOTE: delete line below
+        const moodRating = true
+        setSettings({ workInterval, breakInterval, sound, moodRating})
       })
       .catch(err => {
         if (err.response) {

--- a/src/Context/SettingsContext.js
+++ b/src/Context/SettingsContext.js
@@ -4,7 +4,7 @@ import { getSettings } from '../apiCalls'
 export const SettingsContext = createContext();
 
 export const SettingsProvider = ({ children }) => {
-  const [settings, setSettings] = useState({ workInterval: '25', breakInterval: '5', sound: 'reverbSplash' })
+  const [settings, setSettings] = useState({ workInterval: '25', breakInterval: '5', sound: 'reverbSplash', moodRating: true })
 
   useEffect(() => {
     getSettings()
@@ -12,6 +12,8 @@ export const SettingsProvider = ({ children }) => {
         const workInterval = response.data.work_interval.split(':')[0]
         const breakInterval = response.data.rest_interval.split(':')[0]
         const sound = response.data.sound
+        // const moodRating = response.data.mood_rating
+        //NOTE: add 'moodRating' to setSettings below
         setSettings({ workInterval, breakInterval, sound})
       })
       .catch(err => {

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -9,8 +9,8 @@ export const updateSettings = (settings) => {
   return axios.put(`${rootUrl}/timers/1`, {
     work_interval: settings.workInterval,
     rest_interval: settings.breakInterval,
-    sound: settings.sound
-    //mood: settings.moodRating
+    sound: settings.sound,
+    mood: settings.moodRating
   })
 }
 

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -10,6 +10,7 @@ export const updateSettings = (settings) => {
     work_interval: settings.workInterval,
     rest_interval: settings.breakInterval,
     sound: settings.sound
+    //mood: settings.moodRating
   })
 }
 


### PR DESCRIPTION
# Som Timer Pull Request Form

## Description
This adds a toggle to enable/disable mood ratings in settings, so the user can customize the app even more! 
- Mood added to Settings context 
- In settings, toggle input added for enabling/disabling mood. I currently conditionally render "Disable mood ratings" or "Enable mood ratings" based on whether the toggle is selected or not, but am open to changing that to something static like "Toggle mood ratings" if you think that's better UX. Any feedback welcome! 
- Quite a bit of styling was needed for the toggle in Settings css module 
- Settings tests updated with additional input field
- In Countdown Timer component, conditional rendering added to set next view based on if mood ratings are enabled or not
- In ContentDelivery component, sessionComplete state added, so that that variable can be used to conditionally render the modal if mood ratings are disabled 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:
`Your message here`
## Has This Been Tested?
- [ ] No
- [X] Yes
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
`npm test`
# Message for reviewer:
`See notes above! Open to feedback on styling/wording and anything else!`
# Checklist:
- [X] My code has no unused/commented out code
- [X] My code has no console logs
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas

resolve #97 