### PR TITLE
Feature/jkw statistics initial

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28791,6 +28791,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-minimal-pie-chart": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/react-minimal-pie-chart/-/react-minimal-pie-chart-8.0.1.tgz",
+      "integrity": "sha512-XbWpt3dLuQn0PDLbrTkdkZh21pf5sraJ2fy37VeeCi9+5ndf+Adnr0alBZ0NaA45tMjPhcSig7pB9afrMm/VDQ=="
+    },
     "react-player": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/react-player/-/react-player-2.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "node-sass": "^4.14.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
+    "react-minimal-pie-chart": "^8.0.1",
     "react-player": "^2.6.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.4",

--- a/src/Components/App/App.test.js
+++ b/src/Components/App/App.test.js
@@ -8,7 +8,7 @@ import { SettingsProvider, SettingsContext } from '../../Context/SettingsContext
 import { SessionProvider } from '../../Context/SessionContext'
 import { MemoryRouter } from 'react-router-dom'
 import { UserProvider, UserContext } from '../../Context/UserContext'
-import { getSettings, updateSettings, getRandomContent, postSession } from '../../apiCalls'
+import { getSettings, updateSettings, getRandomContent, postSession, getAllSessions } from '../../apiCalls'
 jest.mock('../../apiCalls.js')
 
 describe('App', () => {
@@ -29,17 +29,43 @@ describe('App', () => {
         sound: "chordCliff",
       },
     })
-    
-    const { getByRole } = render (
-      <SettingsProvider>
-        <UserProvider>
-          <ViewProvider>
-            <SessionProvider>
-              <App />
-            </SessionProvider>
-          </ViewProvider>
-        </UserProvider>
-      </SettingsProvider>
+
+  getAllSessions.mockResolvedValue({
+      "data": {
+        "count": 6,
+        "rests": [
+          {
+            "id": 1,
+            "mood_rating_1": 1,
+            "mood_rating_2": 5,
+            "content_selected": "MEDITATION",
+            "focus_interval": "25",
+            "rest_interval": "5"
+          },
+          {
+            "id": 2,
+            "mood_rating_1": 2,
+            "mood_rating_2": 4,
+            "content_selected": "SOMATIC",
+            "focus_interval": "45",
+            "rest_interval": "15"
+          }
+        ]
+      }
+    })
+
+    const { getByRole, getByAltText, getByText } = render(
+      <MemoryRouter>
+        <SettingsProvider>
+          <UserProvider>
+            <ViewProvider>
+              <SessionProvider>
+                <App />
+              </SessionProvider>
+            </ViewProvider>
+          </UserProvider>
+        </SettingsProvider>
+      </MemoryRouter>
     )
 
     const welcomePrompt = getByRole('heading', { name: /welcome to som timer/i })
@@ -83,13 +109,11 @@ describe('App', () => {
     expect(timerLength).toBeInTheDocument();
     expect(appHeading).toBeInTheDocument();
     expect(timerHeading).toBeInTheDocument();
-
+    
     const statsIcon = getByAltText("stats icon");
     fireEvent.click(statsIcon);
-
-    const statsHeading = getByRole("heading", {
-      name: /stats page coming soon!/i,
-    });
+    
+    const statsHeading = getByRole('heading', { name: /usage/i })
 
     expect(statsHeading).toBeInTheDocument();
 

--- a/src/Components/App/App.test.js
+++ b/src/Components/App/App.test.js
@@ -113,7 +113,7 @@ describe('App', () => {
     const statsIcon = getByAltText("stats icon");
     fireEvent.click(statsIcon);
     
-    const statsHeading = getByRole('heading', { name: /usage/i })
+    const statsHeading = getByRole('heading', { name: /personal statistics/i })
 
     expect(statsHeading).toBeInTheDocument();
 

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -94,10 +94,12 @@ const Stats = ({ toggleTimerView }) => {
   const getAverageMood = (contentSelected, sessions, moodRating) => {
     let sessionData = sessions.reduce((data, session) => {
       if(session.content_selected === contentSelected) {
-        let num = parseInt(session[moodRating])
-        let newSum = data[0] + num
-        let newCount = data[1] + 1
-        data = [newSum, newCount]
+        if(session[moodRating]) {
+          let num = parseInt(session[moodRating])
+          let newSum = data[0] + num
+          let newCount = data[1] + 1
+          data = [newSum, newCount] 
+        }
       }
       return data
 

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -5,23 +5,27 @@ import { getAllSessions } from '../../apiCalls'
 import { PieChart } from 'react-minimal-pie-chart'
 
 const Stats = ({ toggleTimerView }) => {
-  const [sessionsLog, setSessionLog] = useState({
-    count: 0,
-    sessions: []
-  })
+  const [ sessionLog, setSessionLog ] = useState([])
   const [ pieChartData, setPieChartData ] = useState([])
+  const [ frequencyStatistics, setFrequencyStatistics ] = useState({
+    sessionCount: 0,
+    averageFocusInterval: 0,
+    averageRestInterval: 0
+  })
 
   useEffect(() => {
     toggleTimerView(true)
     getAllSessions()
     .then(results => results.data)
     .then(results => {
-      setSessionLog({
-        ...sessionLog,
-        count: results.count,
-        sessions: results.rests
-      })
+      setSessionLog(results.rests)
       createPieChart(results.rests)
+      setFrequencyStatistics({
+        ...frequencyStatistics,
+        sessionCount: results.count,
+        averageFocusInterval: getAverageInterval('focus_interval', results.rests),
+        averageRestInterval: getAverageInterval('rest_interval', results.rests)
+      })
     })
     .catch(error => console.log(error))
   }, [])
@@ -46,6 +50,20 @@ const Stats = ({ toggleTimerView }) => {
     }
 
     return setPieChartData(newPieChartData)
+  }
+
+  const getAverageInterval = (intervalType, sessions) => {
+    let intervalSum = sessions.reduce((sum, session) => {
+      if (session[intervalType]) {
+        let num = parseFloat(session[intervalType])
+        console.log(num)
+        let newSum = sum + num
+        console.log(newSum)
+        return newSum
+      }
+    }, 0)
+
+    return intervalSum / sessions.length
   }
 
   return (
@@ -84,17 +102,17 @@ const Stats = ({ toggleTimerView }) => {
         <section className={style.frequencyModalsContainer}>
           <h3 className={style.frequencyModal}>
             You have completed
-            <h2 className={style.frequencyStatisticValue}>{sessionLog.count}</h2>
+            <h2 className={style.frequencyStatisticValue}>{frequencyStatistics.sessionCount}</h2>
             sessions
           </h3>
           <h3 className={style.frequencyModal}>
             Average focus interval
-            <h2 className={style.frequencyStatisticValue}>{sessionLog.count}</h2>
+            <h2 className={style.frequencyStatisticValue}>{frequencyStatistics.averageFocusInterval}</h2>
             in minutes
           </h3>
           <h3 className={style.frequencyModal}>
             Average rest interval
-            <h2 className={style.frequencyStatisticValue}>{sessionLog.count}</h2>
+            <h2 className={style.frequencyStatisticValue}>{frequencyStatistics.averageRestInterval.toFixed(2)}</h2>
             in minutes
           </h3>
         </section>

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -18,15 +18,13 @@ const Stats = ({ toggleTimerView }) => {
     averageFocusInterval: 0,
     averageRestInterval: 0
   })
-  const [ mood1Statistics, setMood1Statistics ] = useState({
-    somatic: 0,
-    movement: 0,
-    meditation: 0
-  })
-  const [ mood2Statistics, setMood2Statistics ] = useState({
-    somatic: 0,
-    movement: 0,
-    meditation: 0
+  const [ moodStatistics, setMoodStatistics ] = useState({
+    somaticAverageMood1: 0,
+    movementAverageMood1: 0,
+    meditationAverageMood1: 0,
+    somaticAverageMood2: 0,
+    movementAverageMood2: 0,
+    meditationAverageMood2: 0
   })
   const [ user ] = useContext(UserContext)
 
@@ -43,17 +41,14 @@ const Stats = ({ toggleTimerView }) => {
         averageFocusInterval: getAverageInterval('focus_interval', results.rests),
         averageRestInterval: getAverageInterval('rest_interval', results.rests)
       })
-      setMood1Statistics({
-        ...mood1Statistics,
-        somatic: getAverageMood('SOMATIC', results.rests, 'mood_rating_1'),
-        movement: getAverageMood('MOVEMENT', results.rests, 'mood_rating_1'),
-        meditation: getAverageMood('MEDITATION', results.rests, 'mood_rating_1')
-      })
-      setMood2Statistics({
-        ...mood2Statistics,
-        somatic: getAverageMood('SOMATIC', results.rests, 'mood_rating_2'),
-        movement: getAverageMood('MOVEMENT', results.rests, 'mood_rating_2'),
-        meditation: getAverageMood('MEDITATION', results.rests, 'mood_rating_2')
+      setMoodStatistics({
+        ...moodStatistics,
+        somaticAverageMood1: getAverageMood('SOMATIC', results.rests, 'mood_rating_1'),
+        movementAverageMood1: getAverageMood('MOVEMENT', results.rests, 'mood_rating_1'),
+        meditationAverageMood1: getAverageMood('MEDITATION', results.rests, 'mood_rating_1'),
+        somaticAverageMood2: getAverageMood('SOMATIC', results.rests, 'mood_rating_2'),
+        movementAverageMood2: getAverageMood('MOVEMENT', results.rests, 'mood_rating_2'),
+        meditationAverageMood2: getAverageMood('MEDITATION', results.rests, 'mood_rating_2')
       })
     })
     .catch(error => console.log(error))
@@ -218,18 +213,18 @@ const Stats = ({ toggleTimerView }) => {
                   <p className={style.moodWidgetLabel}>
                     Before rest interval
                   </p>
-                  {mood1Statistics.somatic > 0 &&
+                  {moodStatistics.somaticAverageMood1 > 0 &&
                     <img
-                      src={determineFace(mood1Statistics.somatic).icon}
+                      src={determineFace(moodStatistics.somaticAverageMood1).icon}
                       className={style.moodIcon}
-                      style={{ backgroundColor: determineFace(mood1Statistics.somatic).color}}
+                      style={{ backgroundColor: determineFace(moodStatistics.somaticAverageMood1).color}}
                     />
                   }
                   <p 
                     className={style.moodStatisticValue}
                     data-testid='somaticMood1'
                   >
-                    {mood1Statistics.somatic.toFixed(2)}
+                    {moodStatistics.somaticAverageMood1.toFixed(2)}
                   </p>
                 </div>
                 <div className={style.line} />
@@ -237,18 +232,18 @@ const Stats = ({ toggleTimerView }) => {
                   <p className={style.moodWidgetLabel}>
                     After rest interval
                   </p>
-                  {mood2Statistics.somatic > 0 &&
+                  {moodStatistics.somaticAverageMood2 > 0 &&
                     <img
-                      src={determineFace(mood2Statistics.somatic).icon}
+                      src={determineFace(moodStatistics.somaticAverageMood2).icon}
                       className={style.moodIcon}
-                      style={{ backgroundColor: determineFace(mood2Statistics.somatic).color }}
+                      style={{ backgroundColor: determineFace(moodStatistics.somaticAverageMood2).color }}
                     />
                   }
                   <p
                     className={style.moodStatisticValue}
                     data-testid='somaticMood2'
                   >
-                    {mood2Statistics.somatic.toFixed(2)}
+                    {moodStatistics.somaticAverageMood2.toFixed(2)}
                   </p>
                 </div>
               </div>
@@ -263,18 +258,18 @@ const Stats = ({ toggleTimerView }) => {
                   <p className={style.moodWidgetLabel}>
                     Before rest interval
                   </p>
-                  {mood1Statistics.movement > 0 &&
+                  {moodStatistics.movementAverageMood1 > 0 &&
                     <img
-                      src={determineFace(mood1Statistics.movement).icon}
+                      src={determineFace(moodStatistics.movementAverageMood1).icon}
                       className={style.moodIcon}
-                      style={{ backgroundColor: determineFace(mood1Statistics.movement).color }}
+                      style={{ backgroundColor: determineFace(moodStatistics.movementAverageMood1).color }}
                     />
                   }
                   <p 
                     className={style.moodStatisticValue}
                     data-testid='movementMood1'
                   >
-                    {mood1Statistics.movement.toFixed(2)}
+                    {moodStatistics.movementAverageMood1.toFixed(2)}
                   </p>
                 </div>
                 <div className={style.line} />
@@ -282,18 +277,18 @@ const Stats = ({ toggleTimerView }) => {
                   <p className={style.moodWidgetLabel}>
                     After rest interval
                   </p>
-                  {mood2Statistics.movement > 0 &&
+                  {moodStatistics.movementAverageMood2 > 0 &&
                     <img
-                      src={determineFace(mood2Statistics.movement).icon}
+                      src={determineFace(moodStatistics.movementAverageMood2).icon}
                       className={style.moodIcon}
-                      style={{ backgroundColor: determineFace(mood2Statistics.movement).color }}
+                      style={{ backgroundColor: determineFace(moodStatistics.movementAverageMood2).color }}
                     />
                   }
                   <p 
                     className={style.moodStatisticValue}
                     data-testid='movementMood2'
                   >
-                    {mood2Statistics.movement.toFixed(2)}
+                    {moodStatistics.movementAverageMood2.toFixed(2)}
                   </p>
                 </div>
               </div>
@@ -308,18 +303,18 @@ const Stats = ({ toggleTimerView }) => {
                   <p className={style.moodWidgetLabel}>
                     Before rest interval
                   </p>
-                  {mood1Statistics.meditation > 0 &&
+                  {moodStatistics.meditationAverageMood1 > 0 &&
                     <img
-                      src={determineFace(mood1Statistics.meditation).icon}
+                      src={determineFace(moodStatistics.meditationAverageMood1).icon}
                       className={style.moodIcon}
-                      style={{ backgroundColor: determineFace(mood1Statistics.meditation).color }}
+                      style={{ backgroundColor: determineFace(moodStatistics.meditationAverageMood1).color }}
                     />
                   }
                   <p 
                     className={style.moodStatisticValue}
                     data-testid='meditationMood1'
                   >
-                    {mood1Statistics.meditation.toFixed(2)}
+                    {moodStatistics.meditationAverageMood1.toFixed(2)}
                   </p>
                 </div>
                 <div className={style.line} />
@@ -327,18 +322,18 @@ const Stats = ({ toggleTimerView }) => {
                   <p className={style.moodWidgetLabel}>
                     After rest interval
                   </p>
-                  {mood2Statistics.meditation > 0 &&
+                  {moodStatistics.meditationAverageMood2 > 0 &&
                     <img
-                      src={determineFace(mood2Statistics.meditation).icon}
+                      src={determineFace(moodStatistics.meditationAverageMood2).icon}
                       className={style.moodIcon}
-                      style={{ backgroundColor: determineFace(mood2Statistics.meditation).color }}
+                      style={{ backgroundColor: determineFace(moodStatistics.meditationAverageMood2).color }}
                     />
                   }
                   <p 
                     className={style.moodStatisticValue}
                     data-testid='meditationMood2'
                   >
-                    {mood2Statistics.meditation.toFixed(2)}
+                    {moodStatistics.meditationAverageMood2.toFixed(2)}
                   </p>
                 </div>
               </div>

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -3,6 +3,11 @@ import PropTypes from 'prop-types'
 import style from './Stats.module.scss'
 import { getAllSessions } from '../../apiCalls'
 import { PieChart } from 'react-minimal-pie-chart'
+import moodIcon1 from '../../assets/moodIcons/moodIcon1.png'
+import moodIcon2 from '../../assets/moodIcons/moodIcon2.png'
+import moodIcon3 from '../../assets/moodIcons/moodIcon3.png'
+import moodIcon4 from '../../assets/moodIcons/moodIcon4.png'
+import moodIcon5 from '../../assets/moodIcons/moodIcon5.png'
 
 const Stats = ({ toggleTimerView }) => {
   const [ sessionLog, setSessionLog ] = useState([])
@@ -101,6 +106,35 @@ const Stats = ({ toggleTimerView }) => {
     return sessionData[0] / sessionData[1]
   }
 
+  const determineFace = (moodStatistic) => {
+    if (moodStatistic >= 0.5 && moodStatistic < 1.5) {
+      return {
+        icon: moodIcon1, 
+        color: '#9A031E'
+      }
+    } else if (moodStatistic >= 1.5 && moodStatistic < 2.5) {
+      return {
+        icon: moodIcon2, 
+        color: '#DF6407'
+      }
+    } else if (moodStatistic >= 2.5 && moodStatistic < 3.5) {
+      return { 
+        icon: moodIcon3, 
+        color: '#DFAC07'
+      }
+    } else if (moodStatistic >= 3.5 && moodStatistic < 4.5) {
+      return {
+        icon: moodIcon4, 
+        color: '#55A630'
+      }
+    } else if (moodStatistic >= 4.5 && moodStatistic <= 5) {
+      return {
+        icon: moodIcon5, 
+        color: '#007F5F'
+      }
+    }
+  }
+
   return (
     <>
       <h2 className={style.prompt}>Usage</h2>
@@ -178,6 +212,13 @@ const Stats = ({ toggleTimerView }) => {
               <p className={style.moodWidgetLabel}>
                 Before rest interval
               </p>
+              {mood1Statistics.somatic > 0 &&
+                <img
+                  src={determineFace(mood1Statistics.somatic).icon}
+                  className={style.moodIcon}
+                  style={{ backgroundColor: determineFace(mood1Statistics.somatic).color}}
+                />
+              }
               <p 
                 className={style.moodStatistic}
                 data-testid='somaticMood1'
@@ -189,6 +230,13 @@ const Stats = ({ toggleTimerView }) => {
               <p className={style.moodWidgetLabel}>
                 After rest interval
               </p>
+              {mood2Statistics.somatic > 0 &&
+                <img
+                  src={determineFace(mood2Statistics.somatic).icon}
+                  className={style.moodIcon}
+                  style={{ backgroundColor: determineFace(mood2Statistics.somatic).color }}
+                />
+              }
               <p
                 className={style.moodStatistic}
                 data-testid='somaticMood2'
@@ -208,6 +256,13 @@ const Stats = ({ toggleTimerView }) => {
               <p className={style.moodWidgetLabel}>
                 Before rest interval
               </p>
+              {mood1Statistics.movement > 0 &&
+                <img
+                  src={determineFace(mood1Statistics.movement).icon}
+                  className={style.moodIcon}
+                  style={{ backgroundColor: determineFace(mood1Statistics.movement).color }}
+                />
+              }
               <p 
                 className={style.moodStatistic}
                 data-testid='movementMood1'
@@ -219,6 +274,13 @@ const Stats = ({ toggleTimerView }) => {
               <p className={style.moodWidgetLabel}>
                 After rest interval
               </p>
+              {mood2Statistics.movement > 0 &&
+                <img
+                  src={determineFace(mood2Statistics.movement).icon}
+                  className={style.moodIcon}
+                  style={{ backgroundColor: determineFace(mood2Statistics.movement).color }}
+                />
+              }
               <p 
                 className={style.moodStatistic}
                 data-testid='movementMood2'
@@ -238,6 +300,13 @@ const Stats = ({ toggleTimerView }) => {
               <p className={style.moodWidgetLabel}>
                 Before rest interval
               </p>
+              {mood1Statistics.meditation > 0 &&
+                <img
+                  src={determineFace(mood1Statistics.meditation).icon}
+                  className={style.moodIcon}
+                  style={{ backgroundColor: determineFace(mood1Statistics.meditation).color }}
+                />
+              }
               <p 
                 className={style.moodStatistic}
                 data-testid='meditationMood1'
@@ -249,6 +318,13 @@ const Stats = ({ toggleTimerView }) => {
               <p className={style.moodWidgetLabel}>
                 After rest interval
               </p>
+              {mood2Statistics.meditation > 0 &&
+                <img
+                  src={determineFace(mood2Statistics.meditation).icon}
+                  className={style.moodIcon}
+                  style={{ backgroundColor: determineFace(mood2Statistics.meditation).color }}
+                />
+              }
               <p 
                 className={style.moodStatistic}
                 data-testid='meditationMood2'

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -136,7 +136,7 @@ const Stats = ({ toggleTimerView }) => {
 
   return (
     <>
-      <h2 className={style.prompt}>Usage</h2>
+      <h2 className={style.prompt}>Personal Statistics</h2>
       {sessionLog.length ? 
         <>
           <div className={style.frequencyStatisticsContainer}>
@@ -341,7 +341,7 @@ const Stats = ({ toggleTimerView }) => {
           </section>
         </> :
         <h2 className={style.newUserMessage}>
-          You don't have any information to display yet! Spend some time using Som-Timer and then visit this page again to see your Stats.
+          You don't have any information to display yet! Spend some time using Som Timer and then visit this page again to see your Stats.
         </h2>
       }
     </>

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -2,17 +2,44 @@ import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import style from './Stats.module.scss'
 import { getAllSessions } from '../../apiCalls'
+import { PieChart } from 'react-minimal-pie-chart'
 
 const Stats = ({ toggleTimerView }) => {
   const [ sessionsLog, setSessionLog ] = useState(null)
+  const [ pieChartData, setPieChartData ] = useState([])
 
   useEffect(() => {
     toggleTimerView(true)
     getAllSessions()
     .then(results => results.data.rests)
-    .then(rests => setSessionLog(rests))
+    .then(rests => {
+      setSessionLog(rests)
+      createPieChart(rests)
+    })
     .catch(error => console.log(error))
-  })
+  }, [])
+
+  const createPieChart = (rests) => {
+    const newPieChartData = { 
+      somaticTotal: 0, 
+      movementTotal: 0, 
+      meditationTotal: 0 
+    }
+
+    for(let i = 0; i < rests.length; i++) {
+      if(rests[i]['content_selected'] === 'MOVEMENT') {
+        newPieChartData.movementTotal += 1
+      }
+      if (rests[i]['content_selected'] === 'SOMATIC') {
+        newPieChartData.somaticTotal += 1
+      }
+      if (rests[i]['content_selected'] === 'MEDITATION') {
+        newPieChartData.meditationTotal += 1
+      }
+    }
+
+    return setPieChartData(newPieChartData)
+  }
 
   return (
     <article>

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -54,7 +54,8 @@ const Stats = ({ toggleTimerView }) => {
 
   const getAverageInterval = (intervalType, sessions) => {
     let intervalSum = sessions.reduce((sum, session) => {
-      if (session[intervalType]) {
+      if (session[intervalType] !== null) {
+        console.log(session[intervalType])
         let num = parseFloat(session[intervalType])
         console.log(num)
         let newSum = sum + num
@@ -66,10 +67,24 @@ const Stats = ({ toggleTimerView }) => {
     return intervalSum / sessions.length
   }
 
+  const createTableData = () => {
+    return sessionLog.map(session => {
+      return (
+        <tr className={style.tableRow}>
+          <td>{session['focus_interval']}</td>
+          <td>{session['rest_interval']}</td>
+          <td>{session['mood_rating_1']}</td>
+          <td>{session['content_selected']}</td>
+          <td>{session['mood_rating_2']}</td>
+        </tr>
+      )
+    })
+  }
+
   return (
     <>
       <div className={style.frequencyStatisticsContainer}>
-        <section className={style.pieChart}>
+        <section className={style.pieChartContainer}>
           <PieChart
             data={
               [
@@ -83,6 +98,7 @@ const Stats = ({ toggleTimerView }) => {
             labelStyle={{ fontSize: '12px', fontWeight: '600' }}
             label={({ dataEntry }) => Math.round(dataEntry.percentage) + '%'}
             labelPosition={68}
+            className={style.pieChart}
           />
           <section className={style.pieChartLegend}>
             <div className={style.labelContainer}>
@@ -117,6 +133,18 @@ const Stats = ({ toggleTimerView }) => {
           </h3>
         </section>
       </div>
+      <table className={style.sessionLog}>
+        <tr className={style.tableHead}>
+          <th>Focus<br />Interval</th>
+          <th>Break<br />Interval</th>
+          <th>Mood<br />Rating 1</th>
+          <th>Content<br />Selected</th>
+          <th>Mood<br />Rating 2</th>
+        </tr>
+        <div className={style.tableRows}>
+          {createTableData()}
+        </div>
+      </table>
     </>
   )
 }

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -139,14 +139,9 @@ const Stats = ({ toggleTimerView }) => {
 
   return (
     <>
-      {!sessionLog.length && 
-        <h2 className={style.newUserMessage}>
-          You don't have any information to display yet! Spend some time using Som-Timer and then visit this page again to see your Stats.
-        </h2>
-      }
-      {sessionLog.length && 
+      <h2 className={style.prompt}>Usage</h2>
+      {sessionLog.length ? 
         <>
-          <h2 className={style.prompt}>Usage</h2>
           <div className={style.frequencyStatisticsContainer}>
             <section className={style.pieChartContainer}>
               <PieChart
@@ -347,7 +342,10 @@ const Stats = ({ toggleTimerView }) => {
               </div>
             </h4>
           </section>
-        </>
+        </> :
+        <h2 className={style.newUserMessage}>
+          You don't have any information to display yet! Spend some time using Som-Timer and then visit this page again to see your Stats.
+        </h2>
       }
     </>
   )

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -12,10 +12,20 @@ const Stats = ({ toggleTimerView }) => {
     averageFocusInterval: 0,
     averageRestInterval: 0
   })
+  const [ mood1Statistics, setMood1Statistics ] = useState({
+    somatic: 0,
+    movement: 0,
+    meditation: 0
+  })
+  const [ mood2Statistics, setMood2Statistics ] = useState({
+    somatic: 0,
+    movement: 0,
+    meditation: 0
+  })
 
   useEffect(() => {
     toggleTimerView(true)
-    getAllSessions()
+    getAllSessions(1)
     .then(results => results.data)
     .then(results => {
       setSessionLog(results.rests)
@@ -25,6 +35,18 @@ const Stats = ({ toggleTimerView }) => {
         sessionCount: results.count,
         averageFocusInterval: getAverageInterval('focus_interval', results.rests),
         averageRestInterval: getAverageInterval('rest_interval', results.rests)
+      })
+      setMood1Statistics({
+        ...mood1Statistics,
+        somatic: getAverageMood('SOMATIC', results.rests, 'mood_rating_1'),
+        movement: getAverageMood('MOVEMENT', results.rests, 'mood_rating_1'),
+        meditation: getAverageMood('MEDITATION', results.rests, 'mood_rating_1')
+      })
+      setMood2Statistics({
+        ...mood2Statistics,
+        somatic: getAverageMood('SOMATIC', results.rests, 'mood_rating_2'),
+        movement: getAverageMood('MOVEMENT', results.rests, 'mood_rating_2'),
+        meditation: getAverageMood('MEDITATION', results.rests, 'mood_rating_2')
       })
     })
     .catch(error => console.log(error))
@@ -62,6 +84,21 @@ const Stats = ({ toggleTimerView }) => {
     }, 0)
 
     return intervalSum / sessions.length
+  }
+
+  const getAverageMood = (contentSelected, sessions, moodRating) => {
+    let sessionData = sessions.reduce((data, session) => {
+      if(session.content_selected === contentSelected) {
+        let num = parseInt(session[moodRating])
+        let newSum = data[0] + num
+        let newCount = data[1] + 1
+        data = [newSum, newCount]
+      }
+      return data
+
+    }, [0, 0])
+
+    return sessionData[0] / sessionData[1]
   }
 
   return (
@@ -130,6 +167,9 @@ const Stats = ({ toggleTimerView }) => {
           </h3>
         </section>
       </div>
+      <section className={style.moodStatisticsContainer}>
+        
+      </section>
     </>
   )
 }

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -226,6 +226,7 @@ const Stats = ({ toggleTimerView }) => {
                 {mood1Statistics.somatic.toFixed(2)}
               </p>
             </div>
+            <div className={style.line} />
             <div className={style.moodStatsSection}>
               <p className={style.moodWidgetLabel}>
                 After rest interval
@@ -270,6 +271,7 @@ const Stats = ({ toggleTimerView }) => {
                 {mood1Statistics.movement.toFixed(2)}
               </p>
             </div>
+            <div className={style.line} />
             <div className={style.moodStatsSection}>
               <p className={style.moodWidgetLabel}>
                 After rest interval
@@ -314,6 +316,7 @@ const Stats = ({ toggleTimerView }) => {
                 {mood1Statistics.meditation.toFixed(2)}
               </p>
             </div>
+            <div className={style.line} />
             <div className={style.moodStatsSection}>
               <p className={style.moodWidgetLabel}>
                 After rest interval

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -136,8 +136,8 @@ const Stats = ({ toggleTimerView }) => {
             </div>
           </section>
         </section>
-        <section className={style.frequencyModalsContainer}>
-          <h3 className={style.frequencyModal}>
+        <section className={style.frequencyWidgetsContainer}>
+          <h3 className={style.frequencyWidget}>
             You have completed
             <h2 
               className={style.frequencyStatisticValue} data-testid='sessionCount'
@@ -146,7 +146,7 @@ const Stats = ({ toggleTimerView }) => {
             </h2>
             sessions
           </h3>
-          <h3 className={style.frequencyModal}>
+          <h3 className={style.frequencyWidget}>
             Average focus interval
             <h2 
               className={style.frequencyStatisticValue} data-testid='focusIntervalAverage'
@@ -155,7 +155,7 @@ const Stats = ({ toggleTimerView }) => {
             </h2>
             in minutes
           </h3>
-          <h3 className={style.frequencyModal}>
+          <h3 className={style.frequencyWidget}>
             Average rest interval
             <h2 
               className={style.frequencyStatisticValue} 
@@ -167,8 +167,16 @@ const Stats = ({ toggleTimerView }) => {
           </h3>
         </section>
       </div>
-      <section className={style.moodStatisticsContainer}>
-        
+      <section className={style.moodWidgetsContainer}>
+        <h4 className={style.moodWidget}>
+          Somatic Exercises
+        </h4>
+        <h4 className={style.moodWidget}>
+          Yoga/Movement
+        </h4>
+        <h4 className={style.moodWidget}>
+          Meditation/Breathwork
+        </h4>
       </section>
     </>
   )

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -1,10 +1,19 @@
-import React, { useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import style from './Stats.module.scss'
+import { getAllSessions } from '../../apiCalls'
 
 const Stats = ({ toggleTimerView }) => {
-  useEffect(() => toggleTimerView(true))
-  
+  const [ sessionsLog, setSessionLog ] = useState(null)
+
+  useEffect(() => {
+    toggleTimerView(true)
+    getAllSessions()
+    .then(results => results.data.rests)
+    .then(rests => setSessionLog(rests))
+    .catch(error => console.log(error))
+  })
+
   return (
     <article>
       <h2 className={style.prompt}>

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -54,12 +54,9 @@ const Stats = ({ toggleTimerView }) => {
 
   const getAverageInterval = (intervalType, sessions) => {
     let intervalSum = sessions.reduce((sum, session) => {
-      if (session[intervalType] !== null) {
-        console.log(session[intervalType])
+      if (session[intervalType]) {
         let num = parseFloat(session[intervalType])
-        console.log(num)
         let newSum = sum + num
-        console.log(newSum)
         return newSum
       }
     }, 0)
@@ -105,17 +102,30 @@ const Stats = ({ toggleTimerView }) => {
         <section className={style.frequencyModalsContainer}>
           <h3 className={style.frequencyModal}>
             You have completed
-            <h2 className={style.frequencyStatisticValue}>{frequencyStatistics.sessionCount}</h2>
+            <h2 
+              className={style.frequencyStatisticValue} data-testid='sessionCount'
+            >
+              {frequencyStatistics.sessionCount}
+            </h2>
             sessions
           </h3>
           <h3 className={style.frequencyModal}>
             Average focus interval
-            <h2 className={style.frequencyStatisticValue}>{frequencyStatistics.averageFocusInterval.toFixed(2)}</h2>
+            <h2 
+              className={style.frequencyStatisticValue} data-testid='focusIntervalAverage'
+            >
+              {frequencyStatistics.averageFocusInterval.toFixed(2)}
+            </h2>
             in minutes
           </h3>
           <h3 className={style.frequencyModal}>
             Average rest interval
-            <h2 className={style.frequencyStatisticValue}>{frequencyStatistics.averageRestInterval.toFixed(2)}</h2>
+            <h2 
+              className={style.frequencyStatisticValue} 
+              data-testid='restIntervalAverage'
+            >
+              {frequencyStatistics.averageRestInterval.toFixed(2)}
+            </h2>
             in minutes
           </h3>
         </section>

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -67,22 +67,9 @@ const Stats = ({ toggleTimerView }) => {
     return intervalSum / sessions.length
   }
 
-  const createTableData = () => {
-    return sessionLog.map(session => {
-      return (
-        <tr className={style.tableRow}>
-          <td>{session['focus_interval']}</td>
-          <td>{session['rest_interval']}</td>
-          <td>{session['mood_rating_1']}</td>
-          <td>{session['content_selected']}</td>
-          <td>{session['mood_rating_2']}</td>
-        </tr>
-      )
-    })
-  }
-
   return (
     <>
+      <h2 className={style.prompt}>Usage</h2>
       <div className={style.frequencyStatisticsContainer}>
         <section className={style.pieChartContainer}>
           <PieChart
@@ -123,7 +110,7 @@ const Stats = ({ toggleTimerView }) => {
           </h3>
           <h3 className={style.frequencyModal}>
             Average focus interval
-            <h2 className={style.frequencyStatisticValue}>{frequencyStatistics.averageFocusInterval}</h2>
+            <h2 className={style.frequencyStatisticValue}>{frequencyStatistics.averageFocusInterval.toFixed(2)}</h2>
             in minutes
           </h3>
           <h3 className={style.frequencyModal}>
@@ -133,18 +120,6 @@ const Stats = ({ toggleTimerView }) => {
           </h3>
         </section>
       </div>
-      <table className={style.sessionLog}>
-        <tr className={style.tableHead}>
-          <th>Focus<br />Interval</th>
-          <th>Break<br />Interval</th>
-          <th>Mood<br />Rating 1</th>
-          <th>Content<br />Selected</th>
-          <th>Mood<br />Rating 2</th>
-        </tr>
-        <div className={style.tableRows}>
-          {createTableData()}
-        </div>
-      </table>
     </>
   )
 }

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useContext } from 'react'
 import PropTypes from 'prop-types'
 import style from './Stats.module.scss'
 import { getAllSessions } from '../../apiCalls'
@@ -8,6 +8,7 @@ import moodIcon2 from '../../assets/moodIcons/moodIcon2.png'
 import moodIcon3 from '../../assets/moodIcons/moodIcon3.png'
 import moodIcon4 from '../../assets/moodIcons/moodIcon4.png'
 import moodIcon5 from '../../assets/moodIcons/moodIcon5.png'
+import { UserContext } from '../../Context/UserContext'
 
 const Stats = ({ toggleTimerView }) => {
   const [ sessionLog, setSessionLog ] = useState([])
@@ -27,10 +28,11 @@ const Stats = ({ toggleTimerView }) => {
     movement: 0,
     meditation: 0
   })
+  const [user] = useContext(UserContext)
 
   useEffect(() => {
     toggleTimerView(true)
-    getAllSessions(1)
+    getAllSessions(user.userId)
     .then(results => results.data)
     .then(results => {
       setSessionLog(results.rests)

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -12,7 +12,11 @@ import { UserContext } from '../../Context/UserContext'
 
 const Stats = ({ toggleTimerView }) => {
   const [ sessionLog, setSessionLog ] = useState([])
-  const [ pieChartData, setPieChartData ] = useState([])
+  const [ pieChartData, setPieChartData ] = useState({
+    SOMATIC: 0,
+    MOVEMENT: 0,
+    MEDITATION: 0
+  })
   const [ frequencyStatistics, setFrequencyStatistics ] = useState({
     sessionCount: 0,
     averageFocusInterval: 0,
@@ -56,22 +60,15 @@ const Stats = ({ toggleTimerView }) => {
 
   const createPieChart = (rests) => {
     const newPieChartData = { 
-      somaticTotal: 0, 
-      movementTotal: 0, 
-      meditationTotal: 0 
+      SOMATIC: 0, 
+      MOVEMENT: 0, 
+      MEDITATION: 0 
     }
 
-    for(let i = 0; i < rests.length; i++) {
-      if(rests[i]['content_selected'] === 'MOVEMENT') {
-        newPieChartData.movementTotal += 1
-      }
-      if (rests[i]['content_selected'] === 'SOMATIC') {
-        newPieChartData.somaticTotal += 1
-      }
-      if (rests[i]['content_selected'] === 'MEDITATION') {
-        newPieChartData.meditationTotal += 1
-      }
-    }
+    rests.forEach(rest => {
+      const category = rest.content_selected
+      return newPieChartData[category] += 1
+    })
 
     return setPieChartData(newPieChartData)
   }
@@ -144,9 +141,9 @@ const Stats = ({ toggleTimerView }) => {
               <PieChart
                 data={
                   [
-                    { title: 'Yoga', value: pieChartData.movementTotal, color: '#F4D2D0'},
-                    { title: 'Meditation', value: pieChartData.meditationTotal, color: '#7987A1' },
-                    { title: 'Somatics', value: pieChartData.somaticTotal, color: '#FFFFFF' },
+                    { title: 'Yoga', value: pieChartData['MOVEMENT'], color: '#F4D2D0'},
+                    { title: 'Meditation', value: pieChartData['MEDITATION'], color: '#7987A1' },
+                    { title: 'Somatics', value: pieChartData['SOMATIC'], color: '#FFFFFF' },
                   ]
                 }
                 style={{ height: '250px' }}

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -220,7 +220,7 @@ const Stats = ({ toggleTimerView }) => {
                 />
               }
               <p 
-                className={style.moodStatistic}
+                className={style.moodStatisticValue}
                 data-testid='somaticMood1'
               >
                 {mood1Statistics.somatic.toFixed(2)}
@@ -238,7 +238,7 @@ const Stats = ({ toggleTimerView }) => {
                 />
               }
               <p
-                className={style.moodStatistic}
+                className={style.moodStatisticValue}
                 data-testid='somaticMood2'
               >
                 {mood2Statistics.somatic.toFixed(2)}
@@ -264,7 +264,7 @@ const Stats = ({ toggleTimerView }) => {
                 />
               }
               <p 
-                className={style.moodStatistic}
+                className={style.moodStatisticValue}
                 data-testid='movementMood1'
               >
                 {mood1Statistics.movement.toFixed(2)}
@@ -282,7 +282,7 @@ const Stats = ({ toggleTimerView }) => {
                 />
               }
               <p 
-                className={style.moodStatistic}
+                className={style.moodStatisticValue}
                 data-testid='movementMood2'
               >
                 {mood2Statistics.movement.toFixed(2)}
@@ -308,7 +308,7 @@ const Stats = ({ toggleTimerView }) => {
                 />
               }
               <p 
-                className={style.moodStatistic}
+                className={style.moodStatisticValue}
                 data-testid='meditationMood1'
               >
                 {mood1Statistics.meditation.toFixed(2)}
@@ -326,7 +326,7 @@ const Stats = ({ toggleTimerView }) => {
                 />
               }
               <p 
-                className={style.moodStatistic}
+                className={style.moodStatisticValue}
                 data-testid='meditationMood2'
               >
                 {mood2Statistics.meditation.toFixed(2)}

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -42,33 +42,65 @@ const Stats = ({ toggleTimerView }) => {
   }
 
   return (
-    <article>
-      <h2 className={style.prompt}>
-        <span role="img" alt="hourglass emoji" aria-label="hourglass emoji">
-          ⏳
+    <> 
+      <div className={style.pieChart}>
+        <PieChart
+          data={
+            [
+              { title: 'Yoga', value: pieChartData.movementTotal, color: '#F4D2D0'},
+              { title: 'Meditation', value: pieChartData.meditationTotal, color: '#7987A1' },
+              { title: 'Somatics', value: pieChartData.somaticTotal, color: '#FFFFFF' },
+            ]
+          }
+          style={{ height: '250px' }}
+          lineWidth={60}
+          labelStyle={{ fontSize: '12px', fontWeight: '600' }}
+          label={({ dataEntry }) => Math.round(dataEntry.percentage) + '%'}
+          labelPosition={68}
+        />
+        <div className={style.pieChartLegend}>
+          <div className={style.labelContainer}>
+            <p className={style.legendLabel}>Somatic Exercises</p>
+            <div className={style.somaticLabelSwatch} />
+          </div>
+          <div className={style.labelContainer}>
+            <p className={style.legendLabel}>Yoga/Movement </p>
+            <div className={style.movementLabelSwatch} />
+          </div>
+          <div className={style.labelContainer}>
+            <p className={style.legendLabel}>Meditation/Breathwork</p>
+            <div className={style.meditationLabelSwatch} />
+
+          </div>
+        </div>
+      </div>
+      <article>
+        <h2 className={style.prompt}>
+          <span role="img" alt="hourglass emoji" aria-label="hourglass emoji">
+            ⏳
         </span>{" "}
         Stats Page Coming Soon!{" "}
-        <span role="img" alt="hourglass emoji" aria-label="hourglass emoji">
-          ⏳
+          <span role="img" alt="hourglass emoji" aria-label="hourglass emoji">
+            ⏳
         </span>
-      </h2>
-      <section className={style.statsDesc}>
-        <div className={style.line}></div>
-        <p>
-          <strong className={style.strong}>Check back soon</strong> for personal
+        </h2>
+        <section className={style.statsDesc}>
+          <div className={style.line}></div>
+          <p>
+            <strong className={style.strong}>Check back soon</strong> for personal
           stats, so you can see the positive impact Som Timer is having on your
           productivity and mental health. Stats will include data such as a log
           of pom cycles taken, mood and engagement tracking, and what types of
           content work best for you!
         </p>
-        <div className={style.line}></div>
-      </section>
-    </article>
-  );
+          <div className={style.line}></div>
+        </section>
+      </article>
+    </>
+  )
 }
 
 export default Stats
-
 Stats.propTypes = {
   toggleTimerView: PropTypes.func
 }

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -170,12 +170,93 @@ const Stats = ({ toggleTimerView }) => {
       <section className={style.moodWidgetsContainer}>
         <h4 className={style.moodWidget}>
           Somatic Exercises
+          <p className={style.moodAverageLabel}>
+            Average Mood
+          </p>
+          <div className={style.moodStatsContainer}>
+            <div className={style.moodStatsSection}>
+              <p className={style.moodWidgetLabel}>
+                Before rest interval
+              </p>
+              <p 
+                className={style.moodStatistic}
+                data-testid='somaticMood1'
+              >
+                {mood1Statistics.somatic.toFixed(2)}
+              </p>
+            </div>
+            <div className={style.moodStatsSection}>
+              <p className={style.moodWidgetLabel}>
+                After rest interval
+              </p>
+              <p
+                className={style.moodStatistic}
+                data-testid='somaticMood2'
+              >
+                {mood2Statistics.somatic.toFixed(2)}
+              </p>
+            </div>
+          </div>
         </h4>
         <h4 className={style.moodWidget}>
           Yoga/Movement
+          <p className={style.moodAverageLabel}>
+            Average Mood
+          </p>
+          <div className={style.moodStatsContainer}>
+            <div className={style.moodStatsSection}>
+              <p className={style.moodWidgetLabel}>
+                Before rest interval
+              </p>
+              <p 
+                className={style.moodStatistic}
+                data-testid='movementMood1'
+              >
+                {mood1Statistics.movement.toFixed(2)}
+              </p>
+            </div>
+            <div className={style.moodStatsSection}>
+              <p className={style.moodWidgetLabel}>
+                After rest interval
+              </p>
+              <p 
+                className={style.moodStatistic}
+                data-testid='movementMood2'
+              >
+                {mood2Statistics.movement.toFixed(2)}
+              </p>
+            </div>
+          </div>
         </h4>
         <h4 className={style.moodWidget}>
           Meditation/Breathwork
+          <p className={style.moodAverageLabel}>
+            Average Mood
+          </p>
+          <div className={style.moodStatsContainer}>
+            <div className={style.moodStatsSection}>
+              <p className={style.moodWidgetLabel}>
+                Before rest interval
+              </p>
+              <p 
+                className={style.moodStatistic}
+                data-testid='meditationMood1'
+              >
+                {mood1Statistics.meditation.toFixed(2)}
+              </p>
+            </div>
+            <div className={style.moodStatsSection}>
+              <p className={style.moodWidgetLabel}>
+                After rest interval
+              </p>
+              <p 
+                className={style.moodStatistic}
+                data-testid='meditationMood2'
+              >
+                {mood2Statistics.meditation.toFixed(2)}
+              </p>
+            </div>
+          </div>
         </h4>
       </section>
     </>

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -117,28 +117,6 @@ const Stats = ({ toggleTimerView }) => {
           </h3>
         </section>
       </div>
-      <article>
-        <h2 className={style.prompt}>
-          <span role="img" alt="hourglass emoji" aria-label="hourglass emoji">
-            ⏳
-        </span>{" "}
-        Stats Page Coming Soon!{" "}
-          <span role="img" alt="hourglass emoji" aria-label="hourglass emoji">
-            ⏳
-        </span>
-        </h2>
-        <section className={style.statsDesc}>
-          <div className={style.line}></div>
-          <p>
-            <strong className={style.strong}>Check back soon</strong> for personal
-          stats, so you can see the positive impact Som Timer is having on your
-          productivity and mental health. Stats will include data such as a log
-          of pom cycles taken, mood and engagement tracking, and what types of
-          content work best for you!
-        </p>
-          <div className={style.line}></div>
-        </section>
-      </article>
     </>
   )
 }

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -28,7 +28,7 @@ const Stats = ({ toggleTimerView }) => {
     movement: 0,
     meditation: 0
   })
-  const [user] = useContext(UserContext)
+  const [ user ] = useContext(UserContext)
 
   useEffect(() => {
     toggleTimerView(true)

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -36,27 +36,29 @@ const Stats = ({ toggleTimerView }) => {
     toggleTimerView(true)
     getAllSessions(user.userId)
     .then(results => results.data)
-    .then(results => {
-      setSessionLog(results.rests)
-      createPieChart(results.rests)
-      setFrequencyStatistics({
-        ...frequencyStatistics,
-        sessionCount: results.count,
-        averageFocusInterval: getAverageInterval('focus_interval', results.rests),
-        averageRestInterval: getAverageInterval('rest_interval', results.rests)
-      })
-      setMoodStatistics({
-        ...moodStatistics,
-        somaticAverageMood1: getAverageMood('SOMATIC', results.rests, 'mood_rating_1'),
-        movementAverageMood1: getAverageMood('MOVEMENT', results.rests, 'mood_rating_1'),
-        meditationAverageMood1: getAverageMood('MEDITATION', results.rests, 'mood_rating_1'),
-        somaticAverageMood2: getAverageMood('SOMATIC', results.rests, 'mood_rating_2'),
-        movementAverageMood2: getAverageMood('MOVEMENT', results.rests, 'mood_rating_2'),
-        meditationAverageMood2: getAverageMood('MEDITATION', results.rests, 'mood_rating_2')
-      })
-    })
+    .then(results => calculatePersonalStatistics(results))
     .catch(error => console.log(error))
   }, [])
+
+  const calculatePersonalStatistics = (results) => {
+    setSessionLog(results.rests)
+    createPieChart(results.rests)
+    setFrequencyStatistics({
+      ...frequencyStatistics,
+      sessionCount: results.count,
+      averageFocusInterval: getAverageInterval('focus_interval', results.rests),
+      averageRestInterval: getAverageInterval('rest_interval', results.rests)
+    })
+    setMoodStatistics({
+      ...moodStatistics,
+      somaticAverageMood1: getAverageMood('SOMATIC', results.rests, 'mood_rating_1'),
+      movementAverageMood1: getAverageMood('MOVEMENT', results.rests, 'mood_rating_1'),
+      meditationAverageMood1: getAverageMood('MEDITATION', results.rests, 'mood_rating_1'),
+      somaticAverageMood2: getAverageMood('SOMATIC', results.rests, 'mood_rating_2'),
+      movementAverageMood2: getAverageMood('MOVEMENT', results.rests, 'mood_rating_2'),
+      meditationAverageMood2: getAverageMood('MEDITATION', results.rests, 'mood_rating_2')
+    })
+  }
 
   const createPieChart = (rests) => {
     const newPieChartData = { 

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -139,207 +139,216 @@ const Stats = ({ toggleTimerView }) => {
 
   return (
     <>
-      <h2 className={style.prompt}>Usage</h2>
-      <div className={style.frequencyStatisticsContainer}>
-        <section className={style.pieChartContainer}>
-          <PieChart
-            data={
-              [
-                { title: 'Yoga', value: pieChartData.movementTotal, color: '#F4D2D0'},
-                { title: 'Meditation', value: pieChartData.meditationTotal, color: '#7987A1' },
-                { title: 'Somatics', value: pieChartData.somaticTotal, color: '#FFFFFF' },
-              ]
-            }
-            style={{ height: '250px' }}
-            lineWidth={60}
-            labelStyle={{ fontSize: '12px', fontWeight: '600' }}
-            label={({ dataEntry }) => Math.round(dataEntry.percentage) + '%'}
-            labelPosition={68}
-            className={style.pieChart}
-          />
-          <section className={style.pieChartLegend}>
-            <div className={style.labelContainer}>
-              <p className={style.legendLabel}>Somatic Exercises</p>
-              <div className={style.somaticLabelSwatch} />
-            </div>
-            <div className={style.labelContainer}>
-              <p className={style.legendLabel}>Yoga/Movement </p>
-              <div className={style.movementLabelSwatch} />
-            </div>
-            <div className={style.labelContainer}>
-              <p className={style.legendLabel}>Meditation/Breathwork</p>
-              <div className={style.meditationLabelSwatch} />
-            </div>
+      {!sessionLog.length && 
+        <h2 className={style.newUserMessage}>
+          You don't have any information to display yet! Spend some time using Som-Timer and then visit this page again to see your Stats.
+        </h2>
+      }
+      {sessionLog.length && 
+        <>
+          <h2 className={style.prompt}>Usage</h2>
+          <div className={style.frequencyStatisticsContainer}>
+            <section className={style.pieChartContainer}>
+              <PieChart
+                data={
+                  [
+                    { title: 'Yoga', value: pieChartData.movementTotal, color: '#F4D2D0'},
+                    { title: 'Meditation', value: pieChartData.meditationTotal, color: '#7987A1' },
+                    { title: 'Somatics', value: pieChartData.somaticTotal, color: '#FFFFFF' },
+                  ]
+                }
+                style={{ height: '250px' }}
+                lineWidth={60}
+                labelStyle={{ fontSize: '12px', fontWeight: '600' }}
+                label={({ dataEntry }) => Math.round(dataEntry.percentage) + '%'}
+                labelPosition={68}
+                className={style.pieChart}
+              />
+              <section className={style.pieChartLegend}>
+                <div className={style.labelContainer}>
+                  <p className={style.legendLabel}>Somatic Exercises</p>
+                  <div className={style.somaticLabelSwatch} />
+                </div>
+                <div className={style.labelContainer}>
+                  <p className={style.legendLabel}>Yoga/Movement </p>
+                  <div className={style.movementLabelSwatch} />
+                </div>
+                <div className={style.labelContainer}>
+                  <p className={style.legendLabel}>Meditation/Breathwork</p>
+                  <div className={style.meditationLabelSwatch} />
+                </div>
+              </section>
+            </section>
+            <section className={style.frequencyWidgetsContainer}>
+              <h3 className={style.frequencyWidget}>
+                You have completed
+                <h2 
+                  className={style.frequencyStatisticValue} data-testid='sessionCount'
+                >
+                  {frequencyStatistics.sessionCount}
+                </h2>
+                sessions
+              </h3>
+              <h3 className={style.frequencyWidget}>
+                Average focus interval
+                <h2 
+                  className={style.frequencyStatisticValue} data-testid='focusIntervalAverage'
+                >
+                  {frequencyStatistics.averageFocusInterval.toFixed(2)}
+                </h2>
+                in minutes
+              </h3>
+              <h3 className={style.frequencyWidget}>
+                Average rest interval
+                <h2 
+                  className={style.frequencyStatisticValue} 
+                  data-testid='restIntervalAverage'
+                >
+                  {frequencyStatistics.averageRestInterval.toFixed(2)}
+                </h2>
+                in minutes
+              </h3>
+            </section>
+          </div>
+          <section className={style.moodWidgetsContainer}>
+            <h4 className={style.moodWidget}>
+              Somatic Exercises
+              <p className={style.moodAverageLabel}>
+                Average Mood
+              </p>
+              <div className={style.moodStatsContainer}>
+                <div className={style.moodStatsSection}>
+                  <p className={style.moodWidgetLabel}>
+                    Before rest interval
+                  </p>
+                  {mood1Statistics.somatic > 0 &&
+                    <img
+                      src={determineFace(mood1Statistics.somatic).icon}
+                      className={style.moodIcon}
+                      style={{ backgroundColor: determineFace(mood1Statistics.somatic).color}}
+                    />
+                  }
+                  <p 
+                    className={style.moodStatisticValue}
+                    data-testid='somaticMood1'
+                  >
+                    {mood1Statistics.somatic.toFixed(2)}
+                  </p>
+                </div>
+                <div className={style.line} />
+                <div className={style.moodStatsSection}>
+                  <p className={style.moodWidgetLabel}>
+                    After rest interval
+                  </p>
+                  {mood2Statistics.somatic > 0 &&
+                    <img
+                      src={determineFace(mood2Statistics.somatic).icon}
+                      className={style.moodIcon}
+                      style={{ backgroundColor: determineFace(mood2Statistics.somatic).color }}
+                    />
+                  }
+                  <p
+                    className={style.moodStatisticValue}
+                    data-testid='somaticMood2'
+                  >
+                    {mood2Statistics.somatic.toFixed(2)}
+                  </p>
+                </div>
+              </div>
+            </h4>
+            <h4 className={style.moodWidget}>
+              Yoga/Movement
+              <p className={style.moodAverageLabel}>
+                Average Mood
+              </p>
+              <div className={style.moodStatsContainer}>
+                <div className={style.moodStatsSection}>
+                  <p className={style.moodWidgetLabel}>
+                    Before rest interval
+                  </p>
+                  {mood1Statistics.movement > 0 &&
+                    <img
+                      src={determineFace(mood1Statistics.movement).icon}
+                      className={style.moodIcon}
+                      style={{ backgroundColor: determineFace(mood1Statistics.movement).color }}
+                    />
+                  }
+                  <p 
+                    className={style.moodStatisticValue}
+                    data-testid='movementMood1'
+                  >
+                    {mood1Statistics.movement.toFixed(2)}
+                  </p>
+                </div>
+                <div className={style.line} />
+                <div className={style.moodStatsSection}>
+                  <p className={style.moodWidgetLabel}>
+                    After rest interval
+                  </p>
+                  {mood2Statistics.movement > 0 &&
+                    <img
+                      src={determineFace(mood2Statistics.movement).icon}
+                      className={style.moodIcon}
+                      style={{ backgroundColor: determineFace(mood2Statistics.movement).color }}
+                    />
+                  }
+                  <p 
+                    className={style.moodStatisticValue}
+                    data-testid='movementMood2'
+                  >
+                    {mood2Statistics.movement.toFixed(2)}
+                  </p>
+                </div>
+              </div>
+            </h4>
+            <h4 className={style.moodWidget}>
+              Meditation/Breathwork
+              <p className={style.moodAverageLabel}>
+                Average Mood
+              </p>
+              <div className={style.moodStatsContainer}>
+                <div className={style.moodStatsSection}>
+                  <p className={style.moodWidgetLabel}>
+                    Before rest interval
+                  </p>
+                  {mood1Statistics.meditation > 0 &&
+                    <img
+                      src={determineFace(mood1Statistics.meditation).icon}
+                      className={style.moodIcon}
+                      style={{ backgroundColor: determineFace(mood1Statistics.meditation).color }}
+                    />
+                  }
+                  <p 
+                    className={style.moodStatisticValue}
+                    data-testid='meditationMood1'
+                  >
+                    {mood1Statistics.meditation.toFixed(2)}
+                  </p>
+                </div>
+                <div className={style.line} />
+                <div className={style.moodStatsSection}>
+                  <p className={style.moodWidgetLabel}>
+                    After rest interval
+                  </p>
+                  {mood2Statistics.meditation > 0 &&
+                    <img
+                      src={determineFace(mood2Statistics.meditation).icon}
+                      className={style.moodIcon}
+                      style={{ backgroundColor: determineFace(mood2Statistics.meditation).color }}
+                    />
+                  }
+                  <p 
+                    className={style.moodStatisticValue}
+                    data-testid='meditationMood2'
+                  >
+                    {mood2Statistics.meditation.toFixed(2)}
+                  </p>
+                </div>
+              </div>
+            </h4>
           </section>
-        </section>
-        <section className={style.frequencyWidgetsContainer}>
-          <h3 className={style.frequencyWidget}>
-            You have completed
-            <h2 
-              className={style.frequencyStatisticValue} data-testid='sessionCount'
-            >
-              {frequencyStatistics.sessionCount}
-            </h2>
-            sessions
-          </h3>
-          <h3 className={style.frequencyWidget}>
-            Average focus interval
-            <h2 
-              className={style.frequencyStatisticValue} data-testid='focusIntervalAverage'
-            >
-              {frequencyStatistics.averageFocusInterval.toFixed(2)}
-            </h2>
-            in minutes
-          </h3>
-          <h3 className={style.frequencyWidget}>
-            Average rest interval
-            <h2 
-              className={style.frequencyStatisticValue} 
-              data-testid='restIntervalAverage'
-            >
-              {frequencyStatistics.averageRestInterval.toFixed(2)}
-            </h2>
-            in minutes
-          </h3>
-        </section>
-      </div>
-      <section className={style.moodWidgetsContainer}>
-        <h4 className={style.moodWidget}>
-          Somatic Exercises
-          <p className={style.moodAverageLabel}>
-            Average Mood
-          </p>
-          <div className={style.moodStatsContainer}>
-            <div className={style.moodStatsSection}>
-              <p className={style.moodWidgetLabel}>
-                Before rest interval
-              </p>
-              {mood1Statistics.somatic > 0 &&
-                <img
-                  src={determineFace(mood1Statistics.somatic).icon}
-                  className={style.moodIcon}
-                  style={{ backgroundColor: determineFace(mood1Statistics.somatic).color}}
-                />
-              }
-              <p 
-                className={style.moodStatisticValue}
-                data-testid='somaticMood1'
-              >
-                {mood1Statistics.somatic.toFixed(2)}
-              </p>
-            </div>
-            <div className={style.line} />
-            <div className={style.moodStatsSection}>
-              <p className={style.moodWidgetLabel}>
-                After rest interval
-              </p>
-              {mood2Statistics.somatic > 0 &&
-                <img
-                  src={determineFace(mood2Statistics.somatic).icon}
-                  className={style.moodIcon}
-                  style={{ backgroundColor: determineFace(mood2Statistics.somatic).color }}
-                />
-              }
-              <p
-                className={style.moodStatisticValue}
-                data-testid='somaticMood2'
-              >
-                {mood2Statistics.somatic.toFixed(2)}
-              </p>
-            </div>
-          </div>
-        </h4>
-        <h4 className={style.moodWidget}>
-          Yoga/Movement
-          <p className={style.moodAverageLabel}>
-            Average Mood
-          </p>
-          <div className={style.moodStatsContainer}>
-            <div className={style.moodStatsSection}>
-              <p className={style.moodWidgetLabel}>
-                Before rest interval
-              </p>
-              {mood1Statistics.movement > 0 &&
-                <img
-                  src={determineFace(mood1Statistics.movement).icon}
-                  className={style.moodIcon}
-                  style={{ backgroundColor: determineFace(mood1Statistics.movement).color }}
-                />
-              }
-              <p 
-                className={style.moodStatisticValue}
-                data-testid='movementMood1'
-              >
-                {mood1Statistics.movement.toFixed(2)}
-              </p>
-            </div>
-            <div className={style.line} />
-            <div className={style.moodStatsSection}>
-              <p className={style.moodWidgetLabel}>
-                After rest interval
-              </p>
-              {mood2Statistics.movement > 0 &&
-                <img
-                  src={determineFace(mood2Statistics.movement).icon}
-                  className={style.moodIcon}
-                  style={{ backgroundColor: determineFace(mood2Statistics.movement).color }}
-                />
-              }
-              <p 
-                className={style.moodStatisticValue}
-                data-testid='movementMood2'
-              >
-                {mood2Statistics.movement.toFixed(2)}
-              </p>
-            </div>
-          </div>
-        </h4>
-        <h4 className={style.moodWidget}>
-          Meditation/Breathwork
-          <p className={style.moodAverageLabel}>
-            Average Mood
-          </p>
-          <div className={style.moodStatsContainer}>
-            <div className={style.moodStatsSection}>
-              <p className={style.moodWidgetLabel}>
-                Before rest interval
-              </p>
-              {mood1Statistics.meditation > 0 &&
-                <img
-                  src={determineFace(mood1Statistics.meditation).icon}
-                  className={style.moodIcon}
-                  style={{ backgroundColor: determineFace(mood1Statistics.meditation).color }}
-                />
-              }
-              <p 
-                className={style.moodStatisticValue}
-                data-testid='meditationMood1'
-              >
-                {mood1Statistics.meditation.toFixed(2)}
-              </p>
-            </div>
-            <div className={style.line} />
-            <div className={style.moodStatsSection}>
-              <p className={style.moodWidgetLabel}>
-                After rest interval
-              </p>
-              {mood2Statistics.meditation > 0 &&
-                <img
-                  src={determineFace(mood2Statistics.meditation).icon}
-                  className={style.moodIcon}
-                  style={{ backgroundColor: determineFace(mood2Statistics.meditation).color }}
-                />
-              }
-              <p 
-                className={style.moodStatisticValue}
-                data-testid='meditationMood2'
-              >
-                {mood2Statistics.meditation.toFixed(2)}
-              </p>
-            </div>
-          </div>
-        </h4>
-      </section>
+        </>
+      }
     </>
   )
 }

--- a/src/Components/Stats/Stats.js
+++ b/src/Components/Stats/Stats.js
@@ -5,16 +5,23 @@ import { getAllSessions } from '../../apiCalls'
 import { PieChart } from 'react-minimal-pie-chart'
 
 const Stats = ({ toggleTimerView }) => {
-  const [ sessionsLog, setSessionLog ] = useState(null)
+  const [sessionsLog, setSessionLog] = useState({
+    count: 0,
+    sessions: []
+  })
   const [ pieChartData, setPieChartData ] = useState([])
 
   useEffect(() => {
     toggleTimerView(true)
     getAllSessions()
-    .then(results => results.data.rests)
-    .then(rests => {
-      setSessionLog(rests)
-      createPieChart(rests)
+    .then(results => results.data)
+    .then(results => {
+      setSessionLog({
+        ...sessionLog,
+        count: results.count,
+        sessions: results.rests
+      })
+      createPieChart(results.rests)
     })
     .catch(error => console.log(error))
   }, [])
@@ -42,37 +49,55 @@ const Stats = ({ toggleTimerView }) => {
   }
 
   return (
-    <> 
-      <div className={style.pieChart}>
-        <PieChart
-          data={
-            [
-              { title: 'Yoga', value: pieChartData.movementTotal, color: '#F4D2D0'},
-              { title: 'Meditation', value: pieChartData.meditationTotal, color: '#7987A1' },
-              { title: 'Somatics', value: pieChartData.somaticTotal, color: '#FFFFFF' },
-            ]
-          }
-          style={{ height: '250px' }}
-          lineWidth={60}
-          labelStyle={{ fontSize: '12px', fontWeight: '600' }}
-          label={({ dataEntry }) => Math.round(dataEntry.percentage) + '%'}
-          labelPosition={68}
-        />
-        <div className={style.pieChartLegend}>
-          <div className={style.labelContainer}>
-            <p className={style.legendLabel}>Somatic Exercises</p>
-            <div className={style.somaticLabelSwatch} />
-          </div>
-          <div className={style.labelContainer}>
-            <p className={style.legendLabel}>Yoga/Movement </p>
-            <div className={style.movementLabelSwatch} />
-          </div>
-          <div className={style.labelContainer}>
-            <p className={style.legendLabel}>Meditation/Breathwork</p>
-            <div className={style.meditationLabelSwatch} />
-
-          </div>
-        </div>
+    <>
+      <div className={style.frequencyStatisticsContainer}>
+        <section className={style.pieChart}>
+          <PieChart
+            data={
+              [
+                { title: 'Yoga', value: pieChartData.movementTotal, color: '#F4D2D0'},
+                { title: 'Meditation', value: pieChartData.meditationTotal, color: '#7987A1' },
+                { title: 'Somatics', value: pieChartData.somaticTotal, color: '#FFFFFF' },
+              ]
+            }
+            style={{ height: '250px' }}
+            lineWidth={60}
+            labelStyle={{ fontSize: '12px', fontWeight: '600' }}
+            label={({ dataEntry }) => Math.round(dataEntry.percentage) + '%'}
+            labelPosition={68}
+          />
+          <section className={style.pieChartLegend}>
+            <div className={style.labelContainer}>
+              <p className={style.legendLabel}>Somatic Exercises</p>
+              <div className={style.somaticLabelSwatch} />
+            </div>
+            <div className={style.labelContainer}>
+              <p className={style.legendLabel}>Yoga/Movement </p>
+              <div className={style.movementLabelSwatch} />
+            </div>
+            <div className={style.labelContainer}>
+              <p className={style.legendLabel}>Meditation/Breathwork</p>
+              <div className={style.meditationLabelSwatch} />
+            </div>
+          </section>
+        </section>
+        <section className={style.frequencyModalsContainer}>
+          <h3 className={style.frequencyModal}>
+            You have completed
+            <h2 className={style.frequencyStatisticValue}>{sessionLog.count}</h2>
+            sessions
+          </h3>
+          <h3 className={style.frequencyModal}>
+            Average focus interval
+            <h2 className={style.frequencyStatisticValue}>{sessionLog.count}</h2>
+            in minutes
+          </h3>
+          <h3 className={style.frequencyModal}>
+            Average rest interval
+            <h2 className={style.frequencyStatisticValue}>{sessionLog.count}</h2>
+            in minutes
+          </h3>
+        </section>
       </div>
       <article>
         <h2 className={style.prompt}>

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -25,25 +25,58 @@
   filter: drop-shadow(0px 0px 1.5px  $salmonHover);
 }
 
-.pieChart {
+// Container that holds pie chart & descriptive stats modals
+.frequencyStatisticsContainer {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   margin: auto;
-  width: 250px;
+  margin-top: 2.4em;
+  width: 600px;
 }
 
+// Containers for pie chart (left) and descriptive stats (right)
+.pieChartContainer,
+.frequencyModalsContainer {
+  display: flex;
+  flex-direction: column;
+  width: 300px;
+}
+
+.frequencyModalsContainer {
+  justify-content: space-around;
+  align-items: center;
+}
+
+// Frequency modal styling
+.frequencyModal {
+  background-color: #FFFFFF;
+  border-radius: 1em;
+  box-shadow: 0px 0px 20px $darkBlue, inset 0px 0px 5px rgba(0, 0, 0, 0.239);
+  margin: 0;
+  width: 90%;
+  padding: 2% 0 2% 0;
+}
+
+.frequencyStatisticValue {
+  margin: 0;
+  color: $darkBlue
+}
+
+// Container for legend beneath pie chart
 .pieChartLegend {
   display: flex;
   align-items: flex-start;
   flex-direction: column;
 }
 
+// Container that holds legend text & color swatch
 .labelContainer {
   display: flex;
   justify-content: space-between;
   width: 250px;
 }
 
+// Text formatting for pie chart legend
 .legendLabel {
   margin-top: 0.3em;
   font-weight: 600;

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -21,6 +21,8 @@
 .line {
   @include line();
   margin: auto;
+  margin-top: 0.3em;
+  margin-bottom: 0.3em;
 }
 
 .strong {
@@ -82,12 +84,14 @@
 // contains before/after interval, smiley, and avg mood
 .moodStatsSection {
   display: flex;
+  align-items: center;
 }
 
 // text for before / after rest interval
 .moodWidgetLabel {
   width: 50%;
   font-size: 12px;
+  margin: 0;
 }
 
 // text beneath mood widget header
@@ -101,6 +105,7 @@
   width: 30%;
   color: $darkBlue;
   font-weight: bolder;
+  margin: 0;
 }
 
 // mood icon styling on each mood widget

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -72,6 +72,31 @@
   color: $darkBlue
 }
 
+.moodStatsContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.moodStatsSection {
+  display: flex;
+}
+
+.moodWidgetLabel {
+  width: 50%;
+  font-size: 12px;
+}
+
+.moodStatistic {
+  width: 30%;
+  color: $darkBlue;
+  font-weight: bolder;
+}
+
+.moodAverageLabel {
+  margin-top: 0;
+  font-size: 12px;
+}
+
 // Container for legend beneath pie chart
 .pieChartLegend {
   display: flex;

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -97,6 +97,11 @@
   font-size: 12px;
 }
 
+.moodIcon {
+  border-radius: 50%;
+  @include size(40px, 40px)
+}
+
 // Container for legend beneath pie chart
 .pieChartLegend {
   display: flex;

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -165,6 +165,17 @@
   border-radius: 35%;
 }
 
+.newUserMessage {
+  text-align: left; 
+  font-size: 1.2em;
+  margin: 2em auto;
+  width: 505px;
+  padding: .7em 2em; 
+  color: white;
+  background-color: $darkBlue;
+  box-shadow: 0px 0px 20px $darkBlue, inset 0px 0px 5px rgba(0, 0, 0, 0.239);
+  border-radius: 1em;
+}
 
 @media screen and (max-width: 1200px) {
   .statsDesc {

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -72,31 +72,37 @@
   color: $darkBlue
 }
 
+// holds three mood stats widgets
 .moodStatsContainer {
   display: flex;
   flex-direction: column;
 }
 
+// contains before/after interval, smiley, and avg mood
 .moodStatsSection {
   display: flex;
 }
 
+// text for before / after rest interval
 .moodWidgetLabel {
   width: 50%;
   font-size: 12px;
 }
 
-.moodStatistic {
-  width: 30%;
-  color: $darkBlue;
-  font-weight: bolder;
-}
-
+// text beneath mood widget header
 .moodAverageLabel {
   margin-top: 0;
   font-size: 12px;
 }
 
+// average mood statistic text
+.moodStatisticValue {
+  width: 30%;
+  color: $darkBlue;
+  font-weight: bolder;
+}
+
+// mood icon styling on each mood widget
 .moodIcon {
   border-radius: 50%;
   @include size(40px, 40px)

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -108,28 +108,6 @@
   border-radius: 35%;
 }
 
-// Table (session log) styling
-.sessionLog {
-  @include size(600px, 300px);
-  margin: auto;
-  margin-top: 2.4em;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-}
-
-.tableHead {
-  position: sticky;
-  display: flex;
-  justify-content: space-between;
-}
-
-.tableRow {
-  display: flex;
-  align-content: center;
-  justify-content: space-between;
-}
-
 .tableRowsContainer {
   @include size(600px, 300px);
   overflow: scroll;

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -2,6 +2,7 @@
 @import '../../style/mixins.scss';
 
 .prompt {
+  letter-spacing: 1px;
   margin-top: 1.5em;
 }
 

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -89,6 +89,7 @@
   @include size(50px, 18px);
   stroke-linecap: round;
   margin-top: 4px;
+  box-shadow: 0px 0px 5px $darkBlue, inset 0px 0px 5px rgba(0, 0, 0, 0.239);
 }
 
 .somaticLabelSwatch {
@@ -104,6 +105,33 @@
 .meditationLabelSwatch {
   background-color: #7987A1;
   border-radius: 35%;
+}
+
+// Table (session log) styling
+.sessionLog {
+  @include size(600px, 300px);
+  margin: auto;
+  margin-top: 2.4em;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.tableHead {
+  position: sticky;
+  display: flex;
+  justify-content: space-between;
+}
+
+.tableRow {
+  display: flex;
+  align-content: center;
+  justify-content: space-between;
+}
+
+.tableRowsContainer {
+  @include size(600px, 300px);
+  overflow: scroll;
 }
 
 @media screen and (max-width: 1200px) {

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -59,7 +59,7 @@
   justify-content: space-between;
 }
 
-// Frequency widget styling
+// Frequency & mood widget styling
 .frequencyWidget,
 .moodWidget {
   background-color: #FFFFFF;
@@ -68,6 +68,12 @@
   margin: 0;
   width: 90%;
   padding: 2% 0 2% 0;
+}
+
+// Additional mood widget styling
+.moodWidget {
+  margin-left: 0.4em;
+  margin-right: 0.4em;
 }
 
 .frequencyStatisticValue {

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -26,7 +26,7 @@
   filter: drop-shadow(0px 0px 1.5px  $salmonHover);
 }
 
-// Container that holds pie chart & descriptive stats modals
+// Container that holds pie chart & descriptive stats widgets
 .frequencyStatisticsContainer {
   display: flex;
   flex-direction: row;
@@ -35,21 +35,30 @@
   width: 600px;
 }
 
-// Containers for pie chart (left) and descriptive stats (right)
+// Containers for pie chart, descriptive stats, and mood stats
 .pieChartContainer,
-.frequencyModalsContainer {
+.frequencyWidgetsContainer {
   display: flex;
   flex-direction: column;
   width: 300px;
 }
 
-.frequencyModalsContainer {
+.frequencyWidgetsContainer {
   justify-content: space-around;
   align-items: center;
 }
 
-// Frequency modal styling
-.frequencyModal {
+.moodWidgetsContainer {
+  display: flex;
+  width: 600px;
+  margin: auto;
+  margin-top: 1.2em;
+  justify-content: space-between;
+}
+
+// Frequency widget styling
+.frequencyWidget,
+.moodWidget {
   background-color: #FFFFFF;
   border-radius: 1em;
   box-shadow: 0px 0px 20px $darkBlue, inset 0px 0px 5px rgba(0, 0, 0, 0.239);
@@ -108,10 +117,6 @@
   border-radius: 35%;
 }
 
-.tableRowsContainer {
-  @include size(600px, 300px);
-  overflow: scroll;
-}
 
 @media screen and (max-width: 1200px) {
   .statsDesc {

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -25,6 +25,60 @@
   filter: drop-shadow(0px 0px 1.5px  $salmonHover);
 }
 
+.pieChart {
+  display: flex;
+  flex-direction: column;
+  margin: auto;
+  width: 250px;
+}
+
+.pieChartLegend {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.labelContainer {
+  display: flex;
+  justify-content: space-between;
+  width: 250px;
+}
+
+.legendLabel {
+  margin-top: 0.3em;
+  font-weight: 600;
+  margin-bottom: 0;
+}
+
+.somaticLabelSwatch,
+.movementLabelSwatch,
+.meditationLabelSwatch {
+  @include size(50px, 18px);
+  stroke-linecap: round;
+  margin-top: 4px;
+}
+
+.somaticLabelSwatch {
+  background-color: #FFFFFF;
+  border-radius: 35%;
+}
+
+.movementLabelSwatch {
+  background-color: #F4D2D0;
+  border-radius: 35%;
+}
+
+.meditationLabelSwatch {
+  background-color: #7987A1;
+  border-radius: 35%;
+}
+
+@media screen and (max-width: 1200px) {
+  .statsDesc {
+    margin: 2em 8em;
+  }
+}
+
 @media screen and (max-width: 688px) {
   .statsDesc {
     width: 312px;

--- a/src/Components/Stats/Stats.module.scss
+++ b/src/Components/Stats/Stats.module.scss
@@ -19,7 +19,8 @@
 }
 
 .line {
-  @include line()
+  @include line();
+  margin: auto;
 }
 
 .strong {

--- a/src/Components/Stats/Stats.test.js
+++ b/src/Components/Stats/Stats.test.js
@@ -71,29 +71,35 @@ describe('Stats', () => {
     )
   })
 
-  it('should display the correct content when rendered', () => {
+  it('should display the correct content when rendered', async () => {
     
-    const { getByRole, getByText } = render(
+    const { findByRole, getByText, getAllByText } = render(
       <BrowserRouter>
         <Stats toggleTimerView={toggleTimerView} />
       </BrowserRouter>
     )
 
-    const statsHeading = getByRole('heading', { name: /usage/i })
-    const somaticExerciseLabel = getByText(/somatic exercises/i)
-    const movementLabel = getByText(/yoga\/movement/i)
-    const meditationLabel = getByText(/meditation\/breathwork/i)
+    const statsHeading = await findByRole('heading', { name: /usage/i })
+    const somaticExerciseLabel = getAllByText(/somatic exercises/i)
+    const movementLabel = getAllByText(/yoga\/movement/i)
+    const meditationLabel = getAllByText(/meditation\/breathwork/i)
     const sessionCountText = getByText(/you have completed/i)
     const averageFocusIntervalText = getByText(/average focus interval/i)
     const averageRestIntervalText = getByText(/average rest interval/i)
+    const averageMoodText = getAllByText(/average mood/i)
+    const beforeRestText = getAllByText(/before rest interval/i)
+    const afterRestText = getAllByText(/after rest interval/i)
 
     expect(statsHeading).toBeInTheDocument()
-    expect(somaticExerciseLabel).toBeInTheDocument()
-    expect(movementLabel).toBeInTheDocument()
-    expect(meditationLabel).toBeInTheDocument()
+    expect(somaticExerciseLabel).toHaveLength(2)
+    expect(movementLabel).toHaveLength(2)
+    expect(meditationLabel).toHaveLength(2)
     expect(sessionCountText).toBeInTheDocument()
     expect(averageFocusIntervalText).toBeInTheDocument()
     expect(averageRestIntervalText).toBeInTheDocument()
+    expect(averageMoodText).toHaveLength(3)
+    expect(beforeRestText).toHaveLength(3)
+    expect(afterRestText).toHaveLength(3)
   })
 
   it('should render the correct frequency statistics on load', async() => {

--- a/src/Components/Stats/Stats.test.js
+++ b/src/Components/Stats/Stats.test.js
@@ -29,7 +29,7 @@ describe('Stats', () => {
               "id": 2,
               "mood_rating_1": 2,
               "mood_rating_2": 4,
-              "content_selected": "MEDITATION",
+              "content_selected": "SOMATIC",
               "focus_interval": "45",
               "rest_interval": "15"
             },
@@ -71,7 +71,7 @@ describe('Stats', () => {
     )
   })
 
-  it('should display the correct content when rendered', async() => {
+  it('should display the correct content when rendered', () => {
     
     const { getByRole, getByText } = render(
       <BrowserRouter>
@@ -94,6 +94,29 @@ describe('Stats', () => {
     expect(sessionCountText).toBeInTheDocument()
     expect(averageFocusIntervalText).toBeInTheDocument()
     expect(averageRestIntervalText).toBeInTheDocument()
+  })
+
+  it('should render the correct statistics when rendered', async () => {
+    
+    const { findByText, findByTestId } = render(
+      <BrowserRouter>
+        <Stats toggleTimerView={toggleTimerView} />
+      </BrowserRouter>
+    )
+
+    const somaticPercentage = await findByText(/50%/i)
+    const movementPercentage = await findByText(/33%/i)
+    const meditationPercentage = await findByText(/17%/i)
+    const sessionCount = await findByTestId(/sessionCount/i)
+    const focusIntervalAverage = await findByTestId(/focusIntervalAverage/i)
+    const restIntervalAverage = await findByTestId(/restIntervalAverage/i)
+
+    expect(somaticPercentage).toBeInTheDocument()
+    expect(movementPercentage).toBeInTheDocument()
+    expect(meditationPercentage).toBeInTheDocument()
+    expect(sessionCount).toBeInTheDocument()
+    expect(focusIntervalAverage).toBeInTheDocument()
+    expect(restIntervalAverage).toBeInTheDocument()
   })
 
   it('should hide the Homecontainer when rendered', () => {

--- a/src/Components/Stats/Stats.test.js
+++ b/src/Components/Stats/Stats.test.js
@@ -4,6 +4,7 @@ import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { BrowserRouter } from 'react-router-dom'
 import { getAllSessions } from '../../apiCalls'
+import { UserContext } from '../../Context/UserContext'
 jest.mock('../../apiCalls')
 
 describe('Stats', () => {
@@ -23,7 +24,8 @@ describe('Stats', () => {
               "mood_rating_2": 5,
               "content_selected": "MEDITATION",
               "focus_interval": "25",
-              "rest_interval": "5"
+              "rest_interval": "5",
+              "user_id": 4
             },
             {
               "id": 2,
@@ -31,7 +33,8 @@ describe('Stats', () => {
               "mood_rating_2": 4,
               "content_selected": "SOMATIC",
               "focus_interval": "45",
-              "rest_interval": "15"
+              "rest_interval": "15",
+              "user_id": 4
             },
             {
               "id": 3,
@@ -39,7 +42,8 @@ describe('Stats', () => {
               "mood_rating_2": 5,
               "content_selected": "SOMATIC",
               "focus_interval": "30",
-              "rest_interval": "7"
+              "rest_interval": "7",
+              "user_id": 4
             },
             {
               "id": 4,
@@ -47,7 +51,8 @@ describe('Stats', () => {
               "mood_rating_2": 3,
               "content_selected": "SOMATIC",
               "focus_interval": "25",
-              "rest_interval": "5"
+              "rest_interval": "5",
+              "user_id": 4
             },
             {
               "id": 5,
@@ -55,7 +60,8 @@ describe('Stats', () => {
               "mood_rating_2": 5,
               "content_selected": "MOVEMENT",
               "focus_interval": "25",
-              "rest_interval": "5"
+              "rest_interval": "5",
+              "user_id": 4
             },
             {
               "id": 6,
@@ -63,7 +69,8 @@ describe('Stats', () => {
               "mood_rating_2": 3,
               "content_selected": "MOVEMENT",
               "focus_interval": "30",
-              "rest_interval": "15"
+              "rest_interval": "15",
+              "user_id": 4
             },
           ]
         }
@@ -75,7 +82,13 @@ describe('Stats', () => {
     
     const { findByRole, getByText, getAllByText } = render(
       <BrowserRouter>
-        <Stats toggleTimerView={toggleTimerView} />
+        <UserContext.Provider value={[{
+          userName: "Cher",
+          email: "cher@gmail.com",
+          userId: 4
+        }]}>
+          <Stats toggleTimerView={toggleTimerView} />
+        </UserContext.Provider>
       </BrowserRouter>
     )
 
@@ -106,7 +119,13 @@ describe('Stats', () => {
     
     const { findByText, findByTestId } = render(
       <BrowserRouter>
-        <Stats toggleTimerView={toggleTimerView} />
+        <UserContext.Provider value={[{
+          userName: "Cher",
+          email: "cher@gmail.com",
+          userId: 4
+        }]}>
+          <Stats toggleTimerView={toggleTimerView} />
+        </UserContext.Provider>
       </BrowserRouter>
     )
 
@@ -128,7 +147,13 @@ describe('Stats', () => {
   it('should render the correct mood statistics on load', async() => {
     const { findByTestId } = render(
       <BrowserRouter>
-        <Stats toggleTimerView={toggleTimerView} />
+        <UserContext.Provider value={[{
+          userName: "Cher",
+          email: "cher@gmail.com",
+          userId: 4
+        }]}>
+          <Stats toggleTimerView={toggleTimerView} />
+        </UserContext.Provider>
       </BrowserRouter>
     )
     const somaticMood1Average = await findByTestId(/somaticMood1/i)
@@ -150,7 +175,13 @@ describe('Stats', () => {
 
     render(
       <BrowserRouter>
-        <Stats toggleTimerView={toggleTimerView} />
+        <UserContext.Provider value={[{
+          userName: "Cher",
+          email: "cher@gmail.com",
+          userId: 4
+        }]}>
+          <Stats toggleTimerView={toggleTimerView} />
+        </UserContext.Provider>
       </BrowserRouter>
     )
 

--- a/src/Components/Stats/Stats.test.js
+++ b/src/Components/Stats/Stats.test.js
@@ -3,6 +3,8 @@ import Stats from './Stats'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { BrowserRouter } from 'react-router-dom'
+import { getAllSessions } from '../../apiCalls'
+jest.mock('../../apiCalls')
 
 describe('Stats', () => {
 
@@ -10,6 +12,63 @@ describe('Stats', () => {
 
   beforeEach(() => {
     toggleTimerView = jest.fn()
+    getAllSessions.mockResolvedValue(
+      {
+        "data":  {
+          "count": 6,
+          "rests": [
+            {
+              "id": 1,
+              "mood_rating_1": 1,
+              "mood_rating_2": 5,
+              "content_selected": "MEDITATION",
+              "focus_interval": "25",
+              "rest_interval": "5"
+            },
+            {
+              "id": 2,
+              "mood_rating_1": 2,
+              "mood_rating_2": 4,
+              "content_selected": "MEDITATION",
+              "focus_interval": "45",
+              "rest_interval": "15"
+            },
+            {
+              "id": 3,
+              "mood_rating_1": 4,
+              "mood_rating_2": 5,
+              "content_selected": "SOMATIC",
+              "focus_interval": "30",
+              "rest_interval": "7"
+            },
+            {
+              "id": 4,
+              "mood_rating_1": 1,
+              "mood_rating_2": 3,
+              "content_selected": "SOMATIC",
+              "focus_interval": "25",
+              "rest_interval": "5"
+            },
+            {
+              "id": 5,
+              "mood_rating_1": 2,
+              "mood_rating_2": 5,
+              "content_selected": "MOVEMENT",
+              "focus_interval": "25",
+              "rest_interval": "5"
+            },
+            {
+              "id": 6,
+              "mood_rating_1": 1,
+              "mood_rating_2": 3,
+              "content_selected": "MOVEMENT",
+              "focus_interval": "30",
+              "rest_interval": "15"
+            },
+          ]
+        }
+      }
+    )
   })
 
   it('should display the correct content when rendered', () => {
@@ -20,11 +79,15 @@ describe('Stats', () => {
       </BrowserRouter>
     )
 
-    const statsHeading = getByRole('heading', { name: /stats page coming soon!/i })
-    const comingSoonText = getByText(/check back soon/i)
+    const statsHeading = getByRole('heading', { name: /usage/i })
+    const somaticExerciseLabel = getByText(/somatic exercises/i)
+    const movementLabel = getByText(/yoga\/movement/i)
+    const meditationLabel = getByText(/meditation\/breathwork/i)
 
     expect(statsHeading).toBeInTheDocument()
-    expect(comingSoonText).toBeInTheDocument()
+    expect(somaticExerciseLabel).toBeInTheDocument()
+    expect(movementLabel).toBeInTheDocument()
+    expect(meditationLabel).toBeInTheDocument()
   })
 
   it('should hide the Homecontainer when rendered', () => {

--- a/src/Components/Stats/Stats.test.js
+++ b/src/Components/Stats/Stats.test.js
@@ -71,7 +71,7 @@ describe('Stats', () => {
     )
   })
 
-  it('should display the correct content when rendered', () => {
+  it('should display the correct content when rendered', async() => {
     
     const { getByRole, getByText } = render(
       <BrowserRouter>
@@ -83,11 +83,17 @@ describe('Stats', () => {
     const somaticExerciseLabel = getByText(/somatic exercises/i)
     const movementLabel = getByText(/yoga\/movement/i)
     const meditationLabel = getByText(/meditation\/breathwork/i)
+    const sessionCountText = getByText(/you have completed/i)
+    const averageFocusIntervalText = getByText(/average focus interval/i)
+    const averageRestIntervalText = getByText(/average rest interval/i)
 
     expect(statsHeading).toBeInTheDocument()
     expect(somaticExerciseLabel).toBeInTheDocument()
     expect(movementLabel).toBeInTheDocument()
     expect(meditationLabel).toBeInTheDocument()
+    expect(sessionCountText).toBeInTheDocument()
+    expect(averageFocusIntervalText).toBeInTheDocument()
+    expect(averageRestIntervalText).toBeInTheDocument()
   })
 
   it('should hide the Homecontainer when rendered', () => {

--- a/src/Components/Stats/Stats.test.js
+++ b/src/Components/Stats/Stats.test.js
@@ -96,7 +96,7 @@ describe('Stats', () => {
     expect(averageRestIntervalText).toBeInTheDocument()
   })
 
-  it('should render the correct statistics when rendered', async () => {
+  it('should render the correct frequency statistics on load', async() => {
     
     const { findByText, findByTestId } = render(
       <BrowserRouter>
@@ -117,6 +117,27 @@ describe('Stats', () => {
     expect(sessionCount).toBeInTheDocument()
     expect(focusIntervalAverage).toBeInTheDocument()
     expect(restIntervalAverage).toBeInTheDocument()
+  })
+
+  it('should render the correct mood statistics on load', async() => {
+    const { findByTestId } = render(
+      <BrowserRouter>
+        <Stats toggleTimerView={toggleTimerView} />
+      </BrowserRouter>
+    )
+    const somaticMood1Average = await findByTestId(/somaticMood1/i)
+    const movementMood1Average = await findByTestId(/movementMood1/i)
+    const meditationMood1Average = await findByTestId(/meditationMood1/i)
+    const somaticMood2Average = await findByTestId(/somaticMood2/i)
+    const movementMood2Average = await findByTestId(/movementMood2/i)
+    const meditationMood2Average = await findByTestId(/meditationMood2/i)
+
+    expect(somaticMood1Average).toBeInTheDocument()
+    expect(somaticMood2Average).toBeInTheDocument()
+    expect(movementMood1Average).toBeInTheDocument()
+    expect(movementMood2Average).toBeInTheDocument()
+    expect(meditationMood1Average).toBeInTheDocument()
+    expect(meditationMood2Average).toBeInTheDocument()
   })
 
   it('should hide the Homecontainer when rendered', () => {

--- a/src/Components/Stats/Stats.test.js
+++ b/src/Components/Stats/Stats.test.js
@@ -92,7 +92,7 @@ describe('Stats', () => {
       </BrowserRouter>
     )
 
-    const statsHeading = await findByRole('heading', { name: /usage/i })
+    const statsHeading = await findByRole('heading', { name: /personal statistics/i })
     const somaticExerciseLabel = getAllByText(/somatic exercises/i)
     const movementLabel = getAllByText(/yoga\/movement/i)
     const meditationLabel = getAllByText(/meditation\/breathwork/i)

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -36,3 +36,7 @@ export const loginUser = (userName, email) => {
     email
   })
 }
+
+export const getAllSessions = () => {
+  return axios.get(`${rootUrl}/rests`)
+}

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -37,6 +37,6 @@ export const loginUser = (userName, email) => {
   })
 }
 
-export const getAllSessions = () => {
-  return axios.get(`${rootUrl}/rests`)
+export const getAllSessions = (id) => {
+  return axios.get(`${rootUrl}/users/${id}/rests`)
 }


### PR DESCRIPTION
# Som Timer Pull Request Form
## Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
- After getting users hooked up, we are able to render each user a unique statistics page based on their usage. This PR has test code, implementation code, and styling for the new stats page. This page contains usage information including:
     - A pie chart with frequency distribution of which rest activities users are choosing
     - 3 widgets for other frequency statistics (total session count, average rest interval (minutes), average focus interval (minutes)
     - 3 widgets for mood statistics (average pre- and post- mood for every category of content)
          - _Note_: if the mood rating is turned off, mood scores default to `0`. The mood rating average function does not incorporate these `0`s into it's calculation. At some point, we'll need to figure out how to render frequency statistics only (but not mood data) if users have no mood data.
- The stats page is conditionally rendered if a user actually has sessions to do statistics on. New users will receive a message encouraging them to use the app
- Closes #83 
## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:
## Has This Been Tested?
- [ ] No
- [x] Yes
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration:
- Tests are written for the statistics component and can be verified with `npm test`
     - I ran into an issue testing the statistic computations- because our frequency statistics are in their own `<h3>` element nested within the `<h2>`, `getByText` doesn't work here! As such, most of our statistics have `data-testid` properties.
# Checklist:
- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
     - The `.scss` file is heavily commented, as there are a bunch of different containers to get everything looking right!
<img width="1440" alt="Screen Shot 2020-11-29 at 10 03 29 AM" src="https://user-images.githubusercontent.com/62263439/100548499-24105f00-322a-11eb-9af0-ca34859922e1.png">
<img width="1437" alt="Screen Shot 2020-11-29 at 10 03 57 AM" src="https://user-images.githubusercontent.com/62263439/100548506-34283e80-322a-11eb-9596-317377a86c45.png">

